### PR TITLE
Update subscription links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This document is being developed by the Chinese Layout Task Force and the W3C In
 
 Feedback about the content of this document can be submitted via issues or pull request in the GitHub repo. You are also welcome to send your comments to: 
 
-- <mailto:public-i18n-cjk@w3.org>([subscribe](mailto:public-i18n-cjk@w3.org?subject=subscribe)) (for discussion in English);
-- Or <mailto:public-zhreq@w3.org>([subscribe](mailto:public-zhreq@w3.org?subject=subscribe)) and <mailto:public-html-ig-zh@w3.org>([subscribe](mailto:public-html-ig-zh@w3.org?subject=subscribe)) (for discussion in Chinese).
+- <mailto:public-i18n-cjk@w3.org>([subscribe](mailto:public-i18n-cjk-request@w3.org?subject=subscribe)) (for discussion in English);
+- Or <mailto:public-zhreq@w3.org>([subscribe](mailto:public-zhreq-request@w3.org?subject=subscribe)) and <mailto:public-html-ig-zh@w3.org>([subscribe](mailto:public-html-ig-zh-request@w3.org?subject=subscribe)) (for discussion in Chinese).
 
 若对本文档有任何建议或反馈，欢迎通过GitHub提交issues或者pull request。同时也欢迎使用：
 


### PR DESCRIPTION
I’m getting warnings by using the current addresses:

> WARNING:
>   Please try to use 'public-i18n-cjk-request@w3.org'
>   the next time when issuing subscribe requests.
> 
> WARNING:
>   Please try to use 'public-zhreq-request@w3.org'
>   the next time when issuing subscribe requests.
> 
> WARNING:
>   Please try to use 'public-html-ig-zh-request@w3.org'
>   the next time when issuing subscribe requests.
