### PR TITLE
Fix #166

### DIFF
--- a/glossary-pinyin.csv
+++ b/glossary-pinyin.csv
@@ -6,7 +6,7 @@
 標點符號擠壓,标点符号挤压,biāodiǎn fúhào jǐyā,compression rules for consecutive punctuation marks,对位于行首、行尾或連續存在標點符号的其富餘空間進行調整的排版方式。,
 標號,标号,biāohào,indication punctuation marks,標號的作用是標明，主要標示某些成分（主要是詞語）的特定性質和作用。(GB/T 15834-2011),"Puctuation marks for indication, mainly for marking the special nature and function of a part (mainly words) of a sentence."
 標音,标音,biāoyīn,phonetic annotation,為漢字標注發音的方式，主要有行間注等。,"The way to indicate the pronunciation of the Chinese characters, e.g. interlinear annotations."
-比例字體,比例字体,bǐlì zìti,proportional type,西文字體的一种分类，此類字體中各字元的字幅大小不一。,
+比例字體,比例字体,bǐlì zìtǐ,proportional type,西文字體的一种分类，此類字體中各字元的字幅大小不一。,
 出血,出血,chūxiě,bleed,"超出成品幅面范围而被裁切掉的图像。(GB 9851.2-2008, 3.8)","The part of graphics that goes beyond the edge of final page that will be trimmed off."
 大五碼,大五码,Dàwǔmǎ,Big 5,"繁體中文常用的漢字編碼字符集標準之一，共收錄13,060個漢字。",
 地／地腳,地/地脚,dì/dìjiǎo,foot/bottom margin,"版心下沿至成品幅面下沿之间的空白区域。(GB 9851.2-2008, 3.5)。","The bottom margin between the edge of a trimmed page and the type area."
@@ -51,14 +51,14 @@
 欄,栏,lán,column,將連續一系列的文章放在一頁里，按照文字閱讀方向分割成兩個以上的每一個獨立部分。,A partition on a page in multi-column format.
 欄間距,栏间距,lán jiānjù,column gap,欄與欄之間的間距。,Amount of space between columns on a page.
 連接號,连接号,liánjiēhào,dash,見標點符號附錄。,
-羅馬拼音,罗马拼音,luómā pīnyīn,Romanization,將漢字依語言將其發音轉寫為拉丁字母的方式。,"The conversion system of writing from Chinese pronunciation into Roman/Latin script."
+羅馬拼音,罗马拼音,luómǎ pīnyīn,Romanization,將漢字依語言將其發音轉寫為拉丁字母的方式。,"The conversion system of writing from Chinese pronunciation into Roman/Latin script."
 冒號,冒号,màohào,colon,見標點符號附錄。,
 密排,密排,mìpái,Solid setting,將文字依其外框緊密排列的排版方式。,To arrange characters with no inter-character space between adjacent character frames.
 末端,末端,mòduān,end point,文本或文字靠近該行行尾的一端。通常，文字直排時末端在下，橫排在右。,"The ending point of a line, meaning the bottom side in vertical writing mode, or the right side in horizontal writing mode."
 破折號,破折号,pòzhéhào,long dash,見標點符號附錄。,
 輕聲,轻声,qīngshēng,neutral tone,現代標準漢語的特殊變調現象，無固定調値。,"A kind of special tone phenomenon in modern standard Chinese, with no fixed tone."
 齊頭尾對齊,齐头尾对齐,qítóuwěi duìqí,justified alignment,一種段落每行的行頭行尾分別對齊的排版方式。,"The alignment method to align on both the left and right ends of each line of one paragraph text."
-全形/全角,全角/全形,quánxíng/quánjiao,fullwidth,排字的一種相對度量單位，宽度等于所使用的字號，用做排版宽度水平方向的度量。,
+全形／全角,全形/全角,quánxíng/quánjiao,fullwidth,排字的一種相對度量單位，宽度等于所使用的字號，用做排版宽度水平方向的度量。,
 入聲,入声,rùshēng,checked tone,漢語及漢語方言的音節結構，屬四聲之一，其調值之調型短而急促。,"One of four tones in Historical Chinese phonology, which has short and brief pitch."
 刪節號,省略号,shānjiéhào/shěnglüèhào,ellipsis,見標點符號附錄。,
 聲調,声调,shēngdiào,tone,音節的高低升降變化。漢語傳統音韻學里分為平、上、去、入等四聲。,"The pitch contours in language to distinguish lexical or grammatical meaning in one syllable. There are 4 tones, e.g. Ping (level), Shang (rising), Qu (departing), Ru (entering) in Historical Chinese phonology."
@@ -78,7 +78,7 @@
 直角引號,直角引号,zhíjiǎo yǐnhào,corner quotation mark,見標點符號附錄。,
 直排／豎排,直排/竖排,zhípái (shùpái),vertical writing mode,行内每字按垂直方向由上至下，页内每行从右至左、每栏由上至下的排列方法，或者按此方法的排列状态。,"The process or the result of arranging characters on a line from top to bottom, of lines on a page from right to left, and/or of columns on a page from top to bottom."
 中外文對照,中外文对照,Zhōng-wàiwén duìzhào,bilingual annotations,以注文或基文的形式為漢語詞組提示原文或譯文，係行間注排版的一種實作方式。,"To prompt a Chinese term with its original or translation in the form of annotation text or base text, an instance of interlinear annotation."
-中、西文混排處理,中、西文混排处理,Zhōng-Xīwén hùnpái chùlǐ,Chinese and Western mixed text composition,在中文文本中，包含部分西文時的處理方式。,The process of interleaving Chinese text with Western text.
+中、西文混排處理,中、西文混排处理,Zhōng-Xīwén hùnpái chǔlǐ,Chinese and Western mixed text composition,在中文文本中，包含部分西文時的處理方式。,The process of interleaving Chinese text with Western text.
 專名號,专名号,zhuānmínghào,proper name mark,見標點符號附錄。,
 著重號,着重号,zhuózhònghào,emphasis dot,見標點符號附錄。,
 注文,注文,zhùwén,annotation text,行間注排版中，標注於行間（原文字詞或語句旁側）以標注發音或釋義的文字。,Interlinear text run indicating pronunciation or definitions.

--- a/index.html
+++ b/index.html
@@ -1693,9 +1693,9 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
         <p data-lang="zh-hans" class="checkme">排版时，若不希望标点符号出现在行首时，仅能从前一行取最后一个字至下一行，前行多出来的空间采平均排列的方式处理。但若遇连续标点符号，如[。』」]等状况，可能取一个字会造成前行字距过大， 这时则采宽松处理，允许标点出现在行首，以避免字距过松造成体例不良。</p>
         <p data-lang="zh-hant">排版時，若不希望標點符號出現於行頭時，僅能由前行取末字至下一行，前行多出來的空間採平均排列的方式處理。但若遇連續標點符號，如[。』」]等狀況，可能取一字會造成前行字距過大，這時則採寬鬆處理，允許標點出現於行頭，以避免字距過鬆造成體例不良。</p>
       </div>
-      <p data-lang="en">Pause or stop punctuation marks, like slight-pause commas, commas, semicolons, colons, periods, question marks, exclamation marks, as well as right quotation marks, right parentheses, right angle brackets, ellipsis, dashes, etc, should not appear at the line start.</p>
-      <p data-lang="zh-hans" class="checkme">点号（顿号、逗号、句号、冒号、分号、叹号、问号）、结束引号、结束括号、结束乙式书名号（篇名号）、删节号、连接号、间隔号等符号，不能出现在一行的开头。</p>
-      <p data-lang="zh-hant">包括：點號（頓號、逗號、句號、冒號、分號、驚嘆號、問號）、結束引號、結束括號、結束乙式書名號（篇名號）、刪節號、連接號、間隔號等符號，不得出現於一行之首。</p>
+      <p data-lang="en">Pause or stop punctuation marks, like slight-pause commas, commas, semicolons, colons, periods, question marks, exclamation marks, as well as right quotation marks, right parentheses, right angle brackets, dashes, etc, should not appear at the line start.</p>
+      <p data-lang="zh-hans" class="checkme">点号（顿号、逗号、句号、冒号、分号、叹号、问号）、结束引号、结束括号、结束乙式书名号（篇名号）、连接号、间隔号等符号，不能出现在一行的开头。</p>
+      <p data-lang="zh-hant">包括：點號（頓號、逗號、句號、冒號、分號、驚嘆號、問號）、結束引號、結束括號、結束乙式書名號（篇名號）、連接號、間隔號等符號，不得出現於一行之首。</p>
       <p data-lang="en">Left parentheses, left quotation marks, left angle brackets and left title marks should not appear at the line end.</p>
       <p data-lang="zh-hans" class="checkme">开始引号、开始括号、开始单双书名号等符号，不能出现在一行的结尾。</p>
       <p data-lang="zh-hant">包括：開始引號等、開始括號、開始單雙書名號等符號，不得出現於一行之尾。</p>

--- a/index.html
+++ b/index.html
@@ -4427,7 +4427,7 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
       </tr>
       <tr>
         <td>地／地腳</td>
-        <td>地/页脚</td>
+        <td>地/地脚</td>
         <td>dì/dìjiǎo</td>
         <td>footer/foot/bottom margin</td>
         <td>

--- a/index.html
+++ b/index.html
@@ -5023,7 +5023,7 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
       <tr>
         <td>中、西文混排處理</td>
         <td>中、西文混排处理</td>
-        <td>Zhōng-Xīwén hùnpái chùlǐ</td>
+        <td>Zhōng-Xīwén hùnpái chǔlǐ</td>
         <td>Chinese and Western mixed text composition</td>
         <td>
           <p data-lang="en">The process of interleaving Chinese text with Western text.</p>

--- a/index.html
+++ b/index.html
@@ -4862,7 +4862,7 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
       <tr>
         <td>全形/全角</td>
         <td>全角/全形</td>
-        <td>quánxíng/<wbr>quánjiao</td>
+        <td>quánxíng/<wbr>quánjiǎo</td>
         <td>fullwidth</td>
         <td>
           <ol type="a" data-lang="en">

--- a/index.html
+++ b/index.html
@@ -1940,8 +1940,8 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
         </li>
         <li>
           <p data-lang="en">Book titles or authors in references to Western books that use the original spelling.</p>
-          <p data-lang="zh-hans" class="checkme">呈现西文文献等的作者名、书名等采用原本表计的方式呈现。</p>
-          <p data-lang="zh-hant">呈現西文文獻等之作者名、書名等採原本表計的方式呈現。</p>
+          <p data-lang="zh-hans" class="checkme">呈现西文文献等的作者名、书名等采用原本表记的方式呈现。</p>
+          <p data-lang="zh-hant">呈現西文文獻等之作者名、書名等採原本表記的方式呈現。</p>
         </li>
         <li>
           <p data-lang="en">European numerals used to express years or other numbers, such as '1999年'.</p>

--- a/index.html
+++ b/index.html
@@ -4860,8 +4860,8 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
         </td>
       </tr>
       <tr>
+        <td>全形／全角</td>
         <td>全形/全角</td>
-        <td>全角/全形</td>
         <td>quánxíng/<wbr>quánjiǎo</td>
         <td>fullwidth</td>
         <td>

--- a/index.html
+++ b/index.html
@@ -4800,8 +4800,8 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
         <td>column gap</td>
         <td>
           <p data-lang="en">Amount of space between columns on a page.</p>
-          <p data-lang="zh-hans">将连续一系列的文章放在一页里，按照文字阅读方向分割成两个以上的每一个独立部分。</p>
-          <p data-lang="zh-hant">將連續一系列的文章放在一頁里，按照文字閱讀方向分割成兩個以上的每一個獨立部分。</p>
+          <p data-lang="zh-hans">栏与栏之间的间距。</p>
+          <p data-lang="zh-hant">欄與欄之間的間距。</p>
         </td>
       </tr>
       <tr>
@@ -5006,7 +5006,7 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
         <td>
           <p data-lang="en">The process or the result of arranging characters on a line from top to bottom, of lines on a page from right to left, and/or of columns on a page from top to bottom.</p>
           <p data-lang="zh-hans">行内每字按垂直方向由上至下，页内每行从右至左、每栏由上至下的排列方法，或者按此方法的排列状态。</p>
-          <p data-lang="zh-hant">行內每字按水平方向由左至右，頁內每行從上至下、每欄由左至右的排列方法，或者按此方法的排列狀態。</p>
+          <p data-lang="zh-hant">行內每字按垂直方向由上至下，頁內每行從右至左、每欄由上至下的排列方法，或者按此方法的排列狀態。</p>
         </td>
       </tr>
       <tr>

--- a/index.html
+++ b/index.html
@@ -4807,7 +4807,7 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
       <tr>
         <td>羅馬拼音</td>
         <td>罗马拼音</td>
-        <td>luómā pīnyīn</td>
+        <td>luómǎ pīnyīn</td>
         <td>Romanization</td>
         <td>
           <p data-lang="en">The conversion system of writing from Chinese pronunciation into Roman/Latin script.</p>

--- a/index.html
+++ b/index.html
@@ -4390,7 +4390,7 @@ Usually use two <span class="uname">U+2026 HORIZONTAL ELLIPSIS</span>, making up
       <tr>
         <td>比例字體</td>
         <td>比例字体</td>
-        <td>bǐlì zìti</td>
+        <td>bǐlì zìtǐ</td>
         <td>proportional type</td>
         <td>
           <p data-lang="en">A proportional typeface contains glyphs of varying widths


### PR DESCRIPTION
* **FIXED** 3.1.4 節中說刪節號不得出現於一行之首，但根據附錄等其他處的說明，其實是可以的。

-----

* **FIXED** 3.2.1 節中的「表計」當作「表記」。

-----

* **FIXED** 「欄間距」釋義錯誤（與「欄」相同）。

-----

* **FIXED** 「直排／豎排」釋義錯誤（與「橫排」相同）。

-----

* **FIXED** 「比例字體」漢語拼音中「體」應為上聲，誤作輕聲（未標調號）。

-----

* **FIXED** 「地／地腳」的簡體中文為「地/页脚」，但漢語拼音未分別註音。又，既然「天／天頭」在傳統中文與簡體中文裡稱呼一致，且目前又未列「頁眉」條，竊以為這裡簡體中文統一為「地脚」較佳（這個詞在簡體中文裡也是常用的，也與「天頭」相對）。

-----

* 「（開始、結束）括注符號」（共三條）中的「括」字，在簡體中文裡讀「kuo4」（去聲），與傳統中文不同，似應分別註音。
  * 目前我们还没有分别注音的术语，需要讨论如何呈现。

-----

* **FIXED** 「羅馬拼音」漢語拼音中「馬」應為上聲，誤作陰平。

-----

* **FIXED** 「全形／全角」漢語拼音中「角」應為上聲，誤作輕聲（未標調號）。又，這裡簡體中文作「全角/全形」，似是按常見程度排序，但「半形／半角」條未作此處理，排序一致。建議統一處理，且，若按常見程度排序而造成簡體中文順序與傳統中文順序不一致，漢語拼音是否應作相應處理？（所以我個人的偏好是不管常見程度，一律與傳統中文順序一致。）

-----

* **FIXED** 「中、西文混排處理」漢語拼音中「處」應為上聲，誤作去聲。（日常口語中似乎二者都很常見，也不影響交流，但按標準，還是應該標為上聲。極其粗略地講，「處」字作動詞及形容詞時，讀上聲，名詞讀去聲（但作為姓氏時讀上聲）。）