### PR TITLE
Add Chinese language font stacks, addresses #184

### DIFF
--- a/local.css
+++ b/local.css
@@ -1,9 +1,9 @@
 [lang=zh-hant] {
-  font-family: 'Noto Sans CJK TC', 'PingFang TC', 'Heiti TC', 'Microsoft JhengHei', Helvetica, Segoe UI, Arial, sans-serif;
+  font-family: 'PingFang TC', 'Noto Sans CJK TC', 'Heiti TC', 'Microsoft JhengHei', Helvetica, Segoe UI, Arial, sans-serif;
 }
 
 [lang=zh-hans] {
-  font-family: 'Noto Sans CJK SC', 'PingFang SC', 'Heiti SC', 'DengXian', 'Microsoft YaHei', Helvetica, Segoe UI, Arial, sans-serif;
+  font-family: 'PingFang SC', 'Noto Sans CJK SC', 'Heiti SC', 'DengXian', 'Microsoft YaHei', Helvetica, Segoe UI, Arial, sans-serif;
 }
 
 h2 {

--- a/local.css
+++ b/local.css
@@ -1,9 +1,9 @@
 [lang=zh-hant] {
-  font-family: Helvetica, Segoe UI, Arial, 'Noto Sans CJK TC', 'PingFang TC', 'Hei TC', 'Microsoft JhengHei', sans-serif;
+  font-family: 'Noto Sans CJK TC', 'PingFang TC', 'Heiti TC', 'Microsoft JhengHei', Helvetica, Segoe UI, Arial, sans-serif;
 }
 
 [lang=zh-hans] {
-  font-family: Helvetica, Segoe UI, Arial, 'Noto Sans CJK SC', 'PingFang SC', 'Hei SC', 'DengXian', 'Microsoft YaHei', sans-serif;
+  font-family: 'Noto Sans CJK SC', 'PingFang SC', 'Heiti SC', 'DengXian', 'Microsoft YaHei', Helvetica, Segoe UI, Arial, sans-serif;
 }
 
 h2 {

--- a/local.css
+++ b/local.css
@@ -1,3 +1,11 @@
+[lang=zh-hant] {
+  font-family: Helvetica, Segoe UI, Arial, 'Noto Sans CJK TC', 'PingFang TC', 'Hei TC', 'Microsoft JhengHei', sans-serif;
+}
+
+[lang=zh-hans] {
+  font-family: Helvetica, Segoe UI, Arial, 'Noto Sans CJK SC', 'PingFang SC', 'Hei SC', 'DengXian', 'Microsoft YaHei', sans-serif;
+}
+
 h2 {
   margin-top: 3em;
   margin-bottom: 0em;


### PR DESCRIPTION
The CSS applies to elements with the `lang="zh-hans"` and `lang="zh-hant"` attributes respectively. However, I noticed that the generated elements at the top of the document, version and editor names etc., do not have the language attribute on them, is there any way we can add them, otherwise it seems that some Windows machines default to Yu Gothic (which is a Japanese font not a Chinese font).