### PR TITLE
Avoid nested parentheses

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,25 +26,25 @@ var respecConfig = {
     {
       name: "<span lang='zh-hant'>董福興</span> (Bobby TUNG)",
       mailto: "bobbytung@wanderer.tw",
-      company: "特邀专家 (Invited Expert)",
+      company: "特邀专家 / Invited Expert",
       w3cid: 63283
     },
     {
       name: "<span lang='zh-hant'>陳奕鈞</span> (Yijun CHEN)",
       mailto: "ethantw@me.com",
-      company: "特邀专家 (Invited Expert)",
+      company: "特邀专家 / Invited Expert",
       w3cid: 74229
     },
     {
       name: "<span lang='zh-hans'>刘庆</span> (Eric Q. LIU)",
       mailto: "ryukeikun@me.com",
-      company: "特邀专家 (Invited Expert)",
+      company: "特邀专家 / Invited Expert",
       w3cid: 77374
     },
     {
       name: "<span lang='zh-hans'>陈慧晶</span> (Hui Jing CHEN)",
       mailto: "kakyou_tensai@yahoo.com",
-      company: "特邀专家 (Invited Expert)",
+      company: "特邀专家 / Invited Expert",
       w3cid: 79074
     },
     {
@@ -71,7 +71,7 @@ var respecConfig = {
     {
       name: "<span lang='zh-hans'>梁海</span> (Hai LIANG)",
       mailto: "lianghai@gmail.com",
-      company: "特邀专家 (Invited Expert)",
+      company: "特邀专家 / Invited Expert",
       w3cid: 54673
     },
     {
@@ -83,7 +83,7 @@ var respecConfig = {
     {
       name: "<span lang='zh-hans'>张爱杰</span> (Aijie ZHANG)",
       mailto: "zhangaijie_yjs@139.com",
-      company: "中国移动通信集团公司 (China Mobile)",
+      company: "中国移动通信集团公司 / China Mobile",
       w3cid: 81712
     },
   ],


### PR DESCRIPTION
Per @ryukeikun's suggestion, change paren to slash to avoid nested parentheses.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/186.html" title="Last updated on Aug 17, 2018, 2:59 PM GMT (6e115b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/186/431069c...6e115b4.html" title="Last updated on Aug 17, 2018, 2:59 PM GMT (6e115b4)">Diff</a>