### PR TITLE
Fix GitHub link name in bug tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,18 +92,7 @@ var respecConfig = {
   wgURI: "https://www.w3.org/International/core/",
   wgPublicList: "public-i18n-cjk",
 
-  bugTracker: {
-    new: "https://github.com/w3c/clreq/issues",
-    open: "https://github.com/w3c/clreq/issues"
-  },
-
-  otherLinks: [{
-    key: "GitHub",
-    data: [{
-      value: "repository",
-      href: "https://github.com/w3c/clreq"
-    }]
-  }],
+  github: "https://github.com/w3c/clreq",
 
   wgPatentURI: "https://www.w3.org/2004/01/pp-impl/32113/status"
 };

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ var respecConfig = {
   wgURI: "https://www.w3.org/International/core/",
   wgPublicList: "public-i18n-cjk",
 
-  github: "https://github.com/w3c/clreq",
+  github: "w3c/clreq",
 
   wgPatentURI: "https://www.w3.org/2004/01/pp-impl/32113/status"
 };


### PR DESCRIPTION
It seems ReSpec supports `github` field directly: https://github.com/w3c/respec/wiki/github


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/212.html" title="Last updated on May 10, 2019, 7:32 AM UTC (7910402)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/212/540fd68...7910402.html" title="Last updated on May 10, 2019, 7:32 AM UTC (7910402)">Diff</a>