### PR TITLE
Add language tag on the "all" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ var respecConfig = {
     <button onclick="switchLang('zh-hant')" lang="zh-hans">繁體中文</button>
     <button onclick="switchLang('zh-hans')" lang="zh-hant">简体中文</button>
     <button onclick="switchLang('en')" lang="en">English</button>
-    <button onclick="switchLang('all')">All</button>
+    <button onclick="switchLang('all')" lang="en">All</button>
   </p>
 
   <p its-locale-filter-list="zh-hans" lang="zh-hans">本章节描述了本文档的发布状态。其他更新版本可能会覆盖本文档。W3C的文档列表和最新版本可通过<a href="https://www.w3.org/TR/">W3C技术报告</a>索引访问。</p>


### PR DESCRIPTION
Otherwise it will be colored in orange or green when the page is in `zh-hans` or `zh-hant`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/217.html" title="Last updated on May 15, 2019, 10:37 AM UTC (50806d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/217/66fe4bd...50806d6.html" title="Last updated on May 15, 2019, 10:37 AM UTC (50806d6)">Diff</a>