### PR TITLE
Add ids to the Glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -4253,7 +4253,7 @@ var respecConfig = {
     </thead>
 
     <tbody>
-      <tr>
+      <tr id="term.european-numerals">
         <td>阿拉伯數字</td>
         <td>阿拉伯数字</td>
         <td>Ālābó shùzì</td>
@@ -4271,7 +4271,7 @@ var respecConfig = {
             採取比特值法，高位在左，低位在右，從左往右書寫。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.type-area">
         <td>版心</td>
         <td>版心</td>
         <td>bǎnxīn</td>
@@ -4283,7 +4283,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">印刷成品版面中的圖文印刷區域（不含出血圖像）(GB 9851.2-2008, 3.3)。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.halfwidth">
         <td>半形／半角</td>
         <td>半形/半角</td>
         <td>bànxíng/<wbr>bànjiǎo</td>
@@ -4297,7 +4297,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">排字的度量單位，寬度等於同樣字號全角的一半。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.punctuation-marks">
         <td>標點符號</td>
         <td>标点符号</td>
         <td>biāodiǎn fúhào</td>
@@ -4308,7 +4308,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">輔助文字記錄語言的符號，是書面語的有機組成部分，用來表示語句的停頓、語氣以及表示某成分（主要是詞語）的特定性質和作用。(GB/T 15834-2011)</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.punctuation-compression">
         <td>標點符號擠壓</td>
         <td>标点符号挤压</td>
         <td>biāodiǎn fúhào jǐyā</td>
@@ -4320,7 +4320,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">對位於行首、行尾或連續存在標點符號的富餘空間進行調整的排版方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.indication-punctuation-marks">
         <td>標號</td>
         <td>标号</td>
         <td>biāohào</td>
@@ -4331,7 +4331,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">標號的作用是標明，主要標示某些成分（主要是詞語）的特定性質和作用。(GB/T 15834-2011)</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.phonetic-annotation">
         <td>標音</td>
         <td>标音</td>
         <td>biāoyīn</td>
@@ -4342,7 +4342,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為漢字標注發音的方式，主要有行間注等。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.proportional">
         <td>比例字體</td>
         <td>比例字体</td>
         <td>bǐlì zìtǐ</td>
@@ -4355,7 +4355,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">西文字體的一種分類，此類字體中各字元的字幅大小不一。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.bleed">
         <td>出血</td>
         <td>出血</td>
         <td>chūxiě</td>
@@ -4366,7 +4366,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">超出成品幅面範圍而被裁切掉的圖像。(GB 9851.2-2008, 3.8)</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.big5">
         <td>大五碼</td>
         <td>大五码</td>
         <td>Dàwǔmǎ</td>
@@ -4380,7 +4380,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">繁體中文常用的漢字編碼字符集標準之一，共收錄13,060個漢字。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.footer">
         <td>地／地腳</td>
         <td>地/地脚</td>
         <td>dì/dìjiǎo</td>
@@ -4391,7 +4391,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">版心下沿至成品幅面下沿之間的空白區域。(GB 9851.2-2008, 3.5)。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.point">
         <td>點</td>
         <td>点</td>
         <td>diǎn</td>
@@ -4407,7 +4407,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字號的一種計量單位，常用的英美點制下1點約為0.35146mm，也被音譯作「磅（因）」。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.pause-or-stop-punctuation-marks">
         <td>點號</td>
         <td>点号</td>
         <td>diǎnhào</td>
@@ -4418,7 +4418,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">點號的作用是點斷，主要表示停頓和語氣。分為句末點號和句內點號。(GB/T 15834-2011)</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.foot-side">
         <td>底端</td>
         <td>底端</td>
         <td>dǐduān</td>
@@ -4430,7 +4430,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">文本或文字靠近版面結尾的一端。通常，文字直排時底端在左，橫排在下。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.head-side">
         <td>頂端</td>
         <td>顶端</td>
         <td>dǐngduān</td>
@@ -4442,7 +4442,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">文本或文字靠近版面近起始的一端。通常，文字直排時頂端在右，橫排在上。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.paragraph">
         <td>段落</td>
         <td>段落</td>
         <td>duànlùo</td>
@@ -4456,7 +4456,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">由語句組成的句群，一個段落由一至多個語句組成。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.alignment">
         <td>對齊方式</td>
         <td>对齐方式</td>
         <td>duìqí fāngshì</td>
@@ -4472,7 +4472,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">對字、行等各種元素的分布進行整理的方法。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.erhua">
         <td>兒化音</td>
         <td>儿化音</td>
         <td>érhuàyīn</td>
@@ -4484,7 +4484,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">在現代漢語以及一些方音裡，一些詞彙字音的韻母因捲舌動作而發生的音變現象。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.traditional-chinese">
         <td>繁體中文</td>
         <td>繁体中文</td>
         <td>fántǐ Zhōngwén</td>
@@ -4495,7 +4495,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字形及筆畫相對較複雜的漢字體系。因使用時間較長，又名傳統漢字或正體漢字，與之對應者為簡體中文。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.word-pinyin">
         <td>分詞連寫</td>
         <td>分词连写</td>
         <td>fēncí liánxiě</td>
@@ -4506,7 +4506,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">以漢語詞為單位拼寫羅馬拼音的方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.character-pinyin">
         <td>分字連寫</td>
         <td>分字连写</td>
         <td>fēnzì liánxiě</td>
@@ -4517,7 +4517,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">以字為單位拼寫羅馬拼音的方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.unbreakable">
         <td>符號分離禁則</td>
         <td>符号分离禁则</td>
         <td>fúhào fēnlí jìnzé</td>
@@ -4528,7 +4528,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">特定的符號里不得加入空隙的原則。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.widow">
         <td>孤行</td>
         <td>孤行</td>
         <td>gūháng</td>
@@ -4539,7 +4539,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">頁面中首行為前頁最後一個段落的末行者為孤行。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.orphan">
         <td>孤字</td>
         <td>孤字</td>
         <td>gūzì</td>
@@ -4550,7 +4550,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">段落末行僅有一個漢字，或一個漢字加上標點符號，該字即為孤字。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.line-height">
         <td>行高</td>
         <td>行高</td>
         <td>hánggāo</td>
@@ -4561,7 +4561,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">一行的高度，西文裡通常指基線到基線的距離。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.interlinear-comments">
         <td>行間批語</td>
         <td>行间批语</td>
         <td>hángjiān pīyǔ</td>
@@ -4572,7 +4572,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行間的批注，形態自由、長度不拘，時可超過一行。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.interlinear-annotations">
         <td>行間注</td>
         <td>行间注</td>
         <td>hángjiānzhù</td>
@@ -4583,7 +4583,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">標注於行間的說明或文字讀音。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.line-breaking-rules">
         <td>行首行尾禁則</td>
         <td>行首行尾禁则</td>
         <td>hángshǒu hángwěi jìnzé</td>
@@ -4594,7 +4594,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">不同的標點依其性質，不得出現於行首或行尾的排版規則。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.hanging-punctuation">
         <td>行尾點號懸掛</td>
         <td>行尾点号悬挂</td>
         <td>hángwěi diǎnhào xuánguà</td>
@@ -4605,7 +4605,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">將行尾的點號懸掛於版心之外的排版方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.hanyu-pinyin">
         <td>漢語拼音</td>
         <td>汉语拼音</td>
         <td>Hànyǔ pīnyīn</td>
@@ -4616,7 +4616,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">《漢語拼音方案》給漢字注音和拼寫普通話的一種方案，採用拉丁字母，並用附加符號表示聲調，是幫助學習漢字和推廣普通話的工具。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.han-character">
         <td>漢字</td>
         <td>汉字</td>
         <td>Hànzì</td>
@@ -4627,7 +4627,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">中文的基本文字。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.horizontal-writing-mode">
         <td>橫排</td>
         <td>横排</td>
         <td>héngpái</td>
@@ -4638,7 +4638,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行內每字按水平方向由左至右，頁內每行從上至下、每欄由左至右的排列方法，或者按此方法的排列狀態。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.ligature">
         <td>合文</td>
         <td>合文</td>
         <td>héwén</td>
@@ -4649,7 +4649,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">將二字以上的詞組寫作一個漢字書寫單位的形式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.letterpress-printing">
         <td>活字排版</td>
         <td>活字排版</td>
         <td>huózì páibǎn</td>
@@ -4660,7 +4660,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">使用可以移動的字塊進行文字排版及印刷的方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.simplified-chinese">
         <td>簡體中文</td>
         <td>简体中文</td>
         <td>jiǎntǐ Zhōngwén</td>
@@ -4671,7 +4671,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字形及筆畫相對較簡單的漢字體系，主要指中國大陸於20世紀60年代左右公布修訂的簡化漢字，與之對應者為繁體中文。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.brackets">
         <td>夾注符號</td>
         <td>夹注符号</td>
         <td>jiázhù fúhào</td>
@@ -4682,7 +4682,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為提示或突顯將文本夾注起來的一類成對符號的總稱。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="closing-bracket">
         <td>結束夾注符號</td>
         <td>结束夹注符号</td>
         <td>jiéshù jiázhù fúhào</td>
@@ -4693,7 +4693,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">成對的夾注符號（引號、括號、書名號）中，標注結束的字元。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.medial">
         <td>介音</td>
         <td>介音</td>
         <td>jièyīn</td>
@@ -4704,7 +4704,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢語音節的構成中，位於輔音和主要元音之間的過渡音。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.base-text">
         <td>基文</td>
         <td>基文</td>
         <td>jīwén</td>
@@ -4715,7 +4715,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行間注排版中，受標注的原文字詞或語句。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.opening-bracket">
         <td>開始夾注符號</td>
         <td>开始夹注符号</td>
         <td>kāishǐ jiázhù fúhào</td>
@@ -4726,7 +4726,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">成對的夾注符號（引號、括號、書名號）中，標注起始的字元。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.latin-letters">
         <td>拉丁字母</td>
         <td>拉丁字母</td>
         <td>lādīng zìmǔ</td>
@@ -4737,7 +4737,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">西文常用的字母。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.column">
         <td>欄</td>
         <td>栏</td>
         <td>lán</td>
@@ -4748,7 +4748,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">將連續一系列的文章放在一頁里，按照文字閱讀方向分割成兩個以上的每一個獨立部分。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.column-gap">
         <td>欄間距</td>
         <td>栏间距</td>
         <td>lán jiānjù</td>
@@ -4759,7 +4759,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">欄與欄之間的間距。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.romanization">
         <td>羅馬拼音</td>
         <td>罗马拼音</td>
         <td>luómǎ pīnyīn</td>
@@ -4770,7 +4770,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">將漢字依語言將其發音轉寫為拉丁字母的方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.solid-setting">
         <td>密排</td>
         <td>密排</td>
         <td>mìpái</td>
@@ -4781,7 +4781,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">將文字依其外框緊密排列的排版方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.end-point">
         <td>末端</td>
         <td>末端</td>
         <td>mòduān</td>
@@ -4792,7 +4792,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">文本或文字靠近其所在行行尾的一端。通常，文字直排時末端在下，橫排在右。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.neutral-tone">
         <td>輕聲</td>
         <td>轻声</td>
         <td>qīngshēng</td>
@@ -4803,7 +4803,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">現代標準漢語的特殊變調現象，無固定調值。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.justified-alignment">
         <td>齊頭尾對齊</td>
         <td>齐头尾对齐</td>
         <td>qítóuwěi duìqí</td>
@@ -4814,7 +4814,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">一種段落每行的行頭行尾分別對齊的排版方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.fullwidth">
         <td>全形／全角</td>
         <td>全形/全角</td>
         <td>quánxíng/<wbr>quánjiǎo</td>
@@ -4828,7 +4828,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">排字的一種相對度量單位，寬度等於所使用的字號，用做排版寬度水平方向的度量。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.checked-tone">
         <td>入聲</td>
         <td>入声</td>
         <td>rùshēng</td>
@@ -4839,7 +4839,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢語及漢語方言的音節結構，屬四聲之一，其調值之調型短而急促。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.tone">
         <td>聲調</td>
         <td>声调</td>
         <td>shēngdiào</td>
@@ -4850,7 +4850,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">音節的高低升降變化。漢語傳統音韻學裡分為平、上、去、入等四聲。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.initial">
         <td>聲母</td>
         <td>声母</td>
         <td>shēngmǔ</td>
@@ -4861,7 +4861,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢語字音音節開頭的輔音。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.start-point">
         <td>始端</td>
         <td>始端</td>
         <td>shǐduān</td>
@@ -4883,7 +4883,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">於各字之間加入均匀空白的排版方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.top-margin">
         <td>天／天頭</td>
         <td>天/天头</td>
         <td>tiān/tiāntóu</td>
@@ -4894,7 +4894,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">版心上沿至成品幅面上沿之間的空白區域 (GB/T 9851.2-2008, 3.4)</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.typography">
         <td>文字設計／字體排印</td>
         <td>文字设计/字体排印</td>
         <td>wénzìshèjì/<wbr>zìtǐpáiyìn</td>
@@ -4905,7 +4905,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">對文字進行合適地排版讓書面語言易認、易讀、有吸引力地展現出來的一種工藝。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.western-script">
         <td>西文</td>
         <td>西文</td>
         <td>Xīwén</td>
@@ -4916,7 +4916,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">歐洲、美洲和大洋洲通行的文字。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.hyphenation">
         <td>以連字符斷行</td>
         <td>以连字符断行</td>
         <td>yǐ liánzìfú duànháng</td>
@@ -4927,7 +4927,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">在西文詞組音節間插入連字符來斷行的方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.final">
         <td>韻母</td>
         <td>韵母</td>
         <td>yùnmŭ</td>
@@ -4938,7 +4938,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢語字音中一個音節中除聲母、聲調外的部分。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.tab">
         <td>製表定位字元</td>
         <td>制表定位字元</td>
         <td>zhìbiǎo<wbr>dìngwèi<wbr>zìyuán</td>
@@ -4949,7 +4949,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">提供按列對齊文本功能的字元。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.vertical-writing-mode">
         <td>直排／豎排</td>
         <td>直排/竖排</td>
         <td>zhípái (shùpái)</td>
@@ -4960,7 +4960,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行內每字按垂直方向由上至下，頁內每行從右至左、每欄由上至下的排列方法，或者按此方法的排列狀態。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.billingual-annotation">
         <td>中外文對照</td>
         <td>中外文对照</td>
         <td>Zhōng-wàiwén duìzhào</td>
@@ -4971,7 +4971,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">以注文或基文的形式為漢語詞組提示原文或譯文，係行間注排版的一種實作方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.mixed-text-composition">
         <td>中、西文混排處理</td>
         <td>中、西文混排处理</td>
         <td>Zhōng-Xīwén hùnpái chǔlǐ</td>
@@ -4982,7 +4982,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">在中文文本中，包含部分西文时的处理方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.annotation-text">
         <td>注文</td>
         <td>注文</td>
         <td>zhùwén</td>
@@ -4993,7 +4993,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行間注排版中，標注於行間（原文字詞或語句旁側）以標注發音或釋義的文字。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.zhuyin">
         <td>注音符號</td>
         <td>注音符号</td>
         <td>zhùyīn fúhào</td>
@@ -5004,7 +5004,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">「國語注音符號」及「台灣方音符號」的統稱。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.character-advance">
         <td>字幅</td>
         <td>字幅</td>
         <td>zìfú</td>
@@ -5015,7 +5015,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字符在行方向上的大小。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.type-size">
         <td>字號</td>
         <td>字号</td>
         <td>zìhào</td>
@@ -5026,7 +5026,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">區別單個字符大小的表示方法。(GB 9851.2-2008, 3.3)</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.tracking">
         <td>字距</td>
         <td>字距</td>
         <td>zìjù</td>
@@ -5048,7 +5048,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">文字的字身框中，字圖實際分布的空間。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.typeface">
         <td>字體</td>
         <td>字体</td>
         <td>zìtǐ</td>
@@ -5059,7 +5059,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字母、文字或符號的一組集合，一個字體通常有一貫的筆畫與字形風格，用於印刷或螢幕渲染中。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.font">
         <td>字型</td>
         <td>字型</td>
         <td>zìxíng</td>
@@ -5070,7 +5070,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">具有相同基本设计的字形图像集合(GB/T 16964.1-1997, 3.6)，現多與字體混用。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.glyph">
         <td>字形</td>
         <td>字形</td>
         <td>zìxíng</td>
@@ -5081,7 +5081,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字母、文字或符號在書寫、印刷上的形體。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.grid-alignment">
         <td>縱橫對齊</td>
         <td>纵横对齐</td>
         <td>zònghéng duìqí</td>
@@ -5092,7 +5092,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">頭尾對齊的前提下，保證各行文字在橫、縱軸二方向皆相互對齊排列於網格中的排版方式。</p>
         </td>
       </tr>
-      <tr>
+      <tr id="term.horizontal-in-vertical">
         <td>縱中橫排</td>
         <td>纵中横排</td>
         <td>zòng<wbr>zhōng<wbr>héng<wbr>pái</td>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 6, 2020, 8:13 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fclreq%2F78406dcbcbae6d889b9d6c01b24a7ec89ec93d78%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/clreq%23270.)._
</details>
