### PR TITLE
Fix the English translation of 基文

### DIFF
--- a/index.html
+++ b/index.html
@@ -4710,7 +4710,7 @@ var respecConfig = {
         <td>jīwén</td>
         <td>base text</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">A character to be annotated by ruby, ornament characters, or emphasis dots.</p>
+          <p its-locale-filter-list="en" lang="en">Text to be annotated by ruby, ornament characters, or emphasis dots.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行间注排版中，受标注的原文字词或语句。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行間注排版中，受標注的原文字詞或語句。</p>
         </td>


### PR DESCRIPTION
基文 is not necessarily a character. It can be a word, sentence, or even paragraph.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 6, 2020, 9:29 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fclreq%2F5262ad6ddc55d9989772195be86b1c080a123480%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/clreq%23271.)._
</details>
