### PR TITLE
Add reduced inter-character spacing to the Glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -4707,6 +4707,17 @@ var respecConfig = {
         </td>
       </tr>
       <tr>
+        <td>紧排</td>
+        <td>紧排</td>
+        <td>jǐnpái</td>
+        <td>reduced inter-character spacing</td>
+        <td>
+          <p its-locale-filter-list="en" lang="en">Adjustment of inter-character spacing by making the distance between the letter face of adjacent characters shorter than that produced by solid setting.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">减少字距，使文字外框一部分重叠的排版方式。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">減少字距，使文字外框一部分重疊的排版方式。</p>
+        </td>
+      </tr>
+      <tr>
         <td>基文</td>
         <td>基文</td>
         <td>jīwén</td>


### PR DESCRIPTION
English version is from jlreq: https://w3c.github.io/jlreq/#term.tsumegumi


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 9, 2020, 1:25 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fclreq%2F0dcefa64608c14e1abb85ae3f8faffc7bf919ca6%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/clreq%23277.)._
</details>
