### PR TITLE
Editorial fix to Abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ var respecConfig = {
     <p its-locale-filter-list="en" lang="en">Each cultural community has its own language, script and writing system. The transfer of each and every writing system into cyberspace is a task of utmost importance for information and communication technology.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">每一个文化群体都拥有独自的语言、文字、书写系统。将个别书写系统在虚拟空间再现，对文化资产的承继而言，是信息传播技术的重要责任。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">每一個文化群體都擁有獨自的語言、文字、書寫系統。將個別書寫系統在虛擬空間再現，對文化資產的承繼而言，是資訊傳播技術的重要責任。</p>
-    <p its-locale-filter-list="en" lang="en">As one of the basic work items of this task force, this document summarizes the text composition requirements in the Chinese writing system. One of the goals of the task force is to describe the issues in Chinese layout requirements, another is to provide satisfactory equivalents to the current standards (i.e. Unicode), and another is to prompt vendors to implement those relevant features correctly.</p>
+    <p its-locale-filter-list="en" lang="en">As one of the basic work items of this task force, this document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondence with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">作为实现这个责任的基础，本文整理了中文（汉字）书写系统在排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提供与既有标准（如Unicode）的对应，冀求透过本文有效地促进实现。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">作為實現這個責任的基礎，本文整理了中文（漢字）書寫系統在排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提供與既有標準（如Unicode）的對應，冀求透過本文有效地促進實現。</p>
   </section>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ var respecConfig = {
 <body>
 <h1 class="title p-name" id="title">Requirements for Chinese Text Layout<br/><span lang="zh">中文排版需求</span></h1>
 <div id="abstract">
-  <p its-locale-filter-list="en" lang="en"> This document summarizes the text composition requirements in the Chinese writing system. One of the goals of the task force is to describe the issues in the Chinese layout requirements, another one is to provide satisfactory equivalent to the current standards (i.e. Unicode), also to promote vendors to implement those relevant features correctly.</p>
+  <p its-locale-filter-list="en" lang="en"> This document summarizes the text composition requirements in the Chinese writing system. One of the goals of the task force is to describe the issues in the Chinese layout requirements, another one is to provide satisfactory equivalent to the current standards (e.g., Unicode), also to promote vendors to implement those relevant features correctly.</p>
   <p its-locale-filter-list="zh-hans" lang="zh-hans">本文整理了中文（汉字）书写系统于排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提出与既有标准（如Unicode）的对应，冀求本文能更有效地促进实作。</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">本文整理了中文（漢字）書寫系統於排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提出與既有標準（如Unicode）的對應，冀求本文能更有效地促進實作。</p>
 </div>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ var respecConfig = {
 <body>
 <h1 class="title p-name" id="title">Requirements for Chinese Text Layout<br/><span lang="zh">中文排版需求</span></h1>
 <div id="abstract">
-  <p its-locale-filter-list="en" lang="en">This document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondence with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
+  <p its-locale-filter-list="en" lang="en">This document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondences with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
   <p its-locale-filter-list="zh-hans" lang="zh-hans">本文整理了中文（汉字）书写系统于排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提出与既有标准（如Unicode）的对应，冀求本文能更有效地促进实现。</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">本文整理了中文（漢字）書寫系統於排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提出與既有標準（如Unicode）的對應，冀求本文能更有效地促進實作。</p>
 </div>
@@ -198,7 +198,7 @@ var respecConfig = {
     <p its-locale-filter-list="en" lang="en">Each cultural community has its own language, script and writing system. The transfer of each and every writing system into cyberspace is a task of utmost importance for information and communication technology.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">每一个文化群体都拥有独自的语言、文字、书写系统。将个别书写系统在虚拟空间再现，对文化资产的承继而言，是信息传播技术的重要责任。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">每一個文化群體都擁有獨自的語言、文字、書寫系統。將個別書寫系統在虛擬空間再現，對文化資產的承繼而言，是資訊傳播技術的重要責任。</p>
-    <p its-locale-filter-list="en" lang="en">As one of the basic work items of this task force, this document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondence with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
+    <p its-locale-filter-list="en" lang="en">As one of the basic work items of this task force, this document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondences with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">作为实现这个责任的基础，本文整理了中文（汉字）书写系统在排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提供与既有标准（如Unicode）的对应，冀求透过本文有效地促进实现。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">作為實現這個責任的基礎，本文整理了中文（漢字）書寫系統在排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提供與既有標準（如Unicode）的對應，冀求透過本文有效地促進實作。</p>
   </section>

--- a/index.html
+++ b/index.html
@@ -102,8 +102,8 @@ var respecConfig = {
 <body>
 <h1 class="title p-name" id="title">Requirements for Chinese Text Layout<br/><span lang="zh">中文排版需求</span></h1>
 <div id="abstract">
-  <p its-locale-filter-list="en" lang="en"> This document summarizes the text composition requirements in the Chinese writing system. One of the goals of the task force is to describe the issues in the Chinese layout requirements, another one is to provide satisfactory equivalent to the current standards (e.g., Unicode), also to promote vendors to implement those relevant features correctly.</p>
-  <p its-locale-filter-list="zh-hans" lang="zh-hans">本文整理了中文（汉字）书写系统于排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提出与既有标准（如Unicode）的对应，冀求本文能更有效地促进实作。</p>
+  <p its-locale-filter-list="en" lang="en">This document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondence with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">本文整理了中文（汉字）书写系统于排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提出与既有标准（如Unicode）的对应，冀求本文能更有效地促进实现。</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">本文整理了中文（漢字）書寫系統於排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提出與既有標準（如Unicode）的對應，冀求本文能更有效地促進實作。</p>
 </div>
 <div id="sotd">
@@ -200,7 +200,7 @@ var respecConfig = {
     <p its-locale-filter-list="zh-hant" lang="zh-hant">每一個文化群體都擁有獨自的語言、文字、書寫系統。將個別書寫系統在虛擬空間再現，對文化資產的承繼而言，是資訊傳播技術的重要責任。</p>
     <p its-locale-filter-list="en" lang="en">As one of the basic work items of this task force, this document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondence with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">作为实现这个责任的基础，本文整理了中文（汉字）书写系统在排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提供与既有标准（如Unicode）的对应，冀求透过本文有效地促进实现。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">作為實現這個責任的基礎，本文整理了中文（漢字）書寫系統在排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提供與既有標準（如Unicode）的對應，冀求透過本文有效地促進實現。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">作為實現這個責任的基礎，本文整理了中文（漢字）書寫系統在排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提供與既有標準（如Unicode）的對應，冀求透過本文有效地促進實作。</p>
   </section>
 
 


### PR DESCRIPTION
E.g. seems better than i.e. in this context, and that's also what the Chinese text says. (I added a comma after e.g. as well.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/286.html" title="Last updated on Apr 21, 2020, 9:17 AM UTC (6d4bb01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/286/cb2c6a7...6d4bb01.html" title="Last updated on Apr 21, 2020, 9:17 AM UTC (6d4bb01)">Diff</a>