### PR TITLE
Some fixes to the punctuation sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -4793,7 +4793,7 @@ var respecConfig = {
         <td>jiázhù fúhào</td>
         <td>brackets</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">General term for a pair of punctuation marks isolate a segment of text from its surroundings and include additional information for clarification or for emphasis.</p>
+          <p its-locale-filter-list="en" lang="en">General term for a pair of punctuation marks that isolate a segment of text from its surroundings and include additional information for clarification or for emphasis.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">为提示或突显将文本夾注起来的一类成对符号的总称。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為提示或突顯將文本夾注起來的一類成對符號的總稱。</p>
         </td>

--- a/index.html
+++ b/index.html
@@ -1296,7 +1296,7 @@ var respecConfig = {
     <p its-locale-filter-list="zh-hant" lang="zh-hant">在繁、簡中文排版中，標點符號於字面上的位置與形狀差異為二者主要的分歧點（詳見[[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]節）。進行版式配置時，需要多加留意。</p>
 
     <div class="note" id="n020">
-      <p its-locale-filter-list="en" lang="en" class="checkme">CJKV punctuation marks use different glyphs which are visually distinct between languages. Unicode currently does not distinguish each of them with unique codepoints. Usually, we use typefaces corresponding to the locale of the written text or have the layout engines adjust the punctuation marks according to the languages automatically.</p>
+      <p its-locale-filter-list="en" lang="en">CJKV punctuation marks use different glyphs which are visually distinct between languages. Unicode currently does not distinguish each of them with unique codepoints. Usually, we use typefaces corresponding to the locale of the written text or have the layout engines adjust the punctuation marks according to the languages automatically.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">中日韩越意音文字标点符号有地区上的字形与形态差异，但Unicode并未对其区分码位，标点多有共用。通常，排版时使用相应的字体进行配置，或由排版引擎自动调适。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">中日韓越意音文字標點符號有地區上的字形與形態差異，但Unicode並未對其區分碼位，標點多有共用。通常，排版時使用相應的字體進行配置，或由排版引擎自動調適。</p>
     </div>
@@ -1319,7 +1319,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">點號</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en">Pause or stop punctuation marks are used to indicate pauses or the end of a sentence. Some of the pause or stop punctuation marks appear within a sentence, such as slight-pause commas, commas, semicolons, colons, etc., while others appear at the end of a sentence, such as periods, question marks and exclamation marks.</p>
+        <p its-locale-filter-list="en" lang="en">Pause or stop punctuation marks are used to indicate pauses or the end of a sentence. Some of the pause or stop punctuation marks appear within a sentence, such as secondary commas, commas, semicolons, colons, etc., while others appear at the end of a sentence, such as periods, question marks and exclamation marks.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">点号相对于标号，用于表示语句的停顿或暂停。分为句内点号，如顿号、逗号、分号、冒号等；以及句末点号，如句号、问号、感叹号等。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">點號相對於標號，用於表示語句的停頓或暫停。分為句內點號，如頓號、逗號、分號、冒號等；以及句末點號，如句號、問號、驚嘆號等。</p>
         <ol>
@@ -1328,7 +1328,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">句号、逗号与顿号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">句號、逗號與頓號</span></p>
 
-            <p its-locale-filter-list="en" lang="en">Periods <span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP</span> [。] are punctuation marks placed at the end of a sentence. Commas <span class="uname" translate="no">U+FF0C FULLWIDTH COMMA</span> [，] are mainly used for separating parts of a sentence such as clauses, and items in lists, particularly when there are three or more items listed. Secondary commas <span class="uname" translate="no">U+3001 IDEOGRAPHIC COMMA</span> [、] are usually used to separate items in lists, as a way to show sequence.</p>
+            <p its-locale-filter-list="en" lang="en">Periods <span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP</span> [。] are punctuation marks placed at the end of a sentence. Commas <span class="uname" translate="no">U+FF0C FULLWIDTH COMMA</span> [，] are mainly used for separating parts of a sentence such as clauses. Secondary commas (also known as slight-pause commas or enumeration commas) <span class="uname" translate="no">U+3001 IDEOGRAPHIC COMMA</span> [、] are usually used to separate items in lists, particularly when there are three or more items listed.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">句号<span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP </span>[。]表示语句结束，逗号<span class="uname" translate="no">U+FF0C FULLWIDTH COMMA </span>[，]表示语气停顿，顿号<span class="uname" translate="no">U+3001 IDEOGRAPHIC COMMA</span> [、]使用于并列连用、表示次序的字词之间。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">句號<span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP </span>[。]表示語句結束，逗號<span class="uname" translate="no">U+FF0C FULLWIDTH COMMA </span>[，]表示語氣停頓，頓號<span class="uname" translate="no">U+3001 IDEOGRAPHIC COMMA</span> [、]使用於並列連用、表示次序的字詞之間。</p>
 
@@ -1342,7 +1342,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Colons and semicolons.</span> </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">冒号与分号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">冒號與分號</span></p>
-            <p its-locale-filter-list="en" lang="en"><span class="uname" translate="no">U+FF1A FULLWIDTH COLON</span> [：] consists of two equally sized dots centered on the same vertical line. It is used to start an enumeration. <span class="uname" translate="no">U+FF1B FULLWIDTH SEMICOLON</span> [；] is a punctuation mark that separates major sentence elements. A semicolon can be used between two closely related independent clauses, provided they are not already joined by a coordinating conjunction.</p>
+            <p its-locale-filter-list="en" lang="en"><span class="uname" translate="no">U+FF1A FULLWIDTH COLON</span> [：] consists of two equally sized dots centered on the same vertical line. It is used to start an explanation or a list. <span class="uname" translate="no">U+FF1B FULLWIDTH SEMICOLON</span> [；] is a punctuation mark that separates major sentence elements. A semicolon can be used between two closely related independent clauses, provided they are not already joined by a coordinating conjunction.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">冒号<span class="uname" translate="no">U+FF1A FULLWIDTH COLON</span> [：]、分号<span class="uname" translate="no">U+FF1B FULLWIDTH SEMICOLON</span> [；]。冒号表示引述语句开始；分号用于语句间，表示意义转折。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">冒號<span class="uname" translate="no">U+FF1A FULLWIDTH COLON</span> [：]、分號<span class="uname" translate="no">U+FF1B FULLWIDTH SEMICOLON</span> [；]。冒號表示引述語句開始；分號用於語句間，表示意義轉折。</p>
           </li>
@@ -1364,7 +1364,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標號</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include brackets, parentheses, em dashes, horizontal ellipses, black circles or bullets, tildes, middle dots, angle brackets, low lines, and solidus.</p>
+        <p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses, em dashes, horizontal ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于点号，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於點號，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
         <ol>
@@ -1372,7 +1372,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Quotation Marks</span></p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">引号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">引號</span></p>
-            <p its-locale-filter-list="en" lang="en">Quotation marks, usually used in pairs, are commonly used to emphasize certain characters or words, or to indicate the beginning and ending of the dialog or quoted content. If there is a need to use a bracket within a pair of brackets, the shape of the inner quotation marks will differ from the parent quotation marks. Quotation marks are a kind of bracket.</p>
+            <p its-locale-filter-list="en" lang="en">Quotation marks, usually used in pairs, are commonly used to emphasize certain characters or words, or to indicate the beginning and ending of the dialog or quoted content. If there is a need to use a pair of quotation marks inside a pair of quotation marks, the shape of the inner quotation marks will differ from the parent quotation marks. Quotation marks are a kind of bracket.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">引号用于强调字词，或作为引用话语、文献的起讫边界。引号中再次使用引号时，使用内引号。外引号与内引号有字形上的差异以便识别。引号属于夹注符号。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">引號用於強調字詞，或作為引用話語、文獻的起訖邊界。引號中再次使用引號時，使用內引號。外引號與內引號有字形上的差異以便識別。引號屬於夾注符號。</p>
             <p its-locale-filter-list="en" lang="en">When there is a need for quotation marks, Taiwan will apply single quotation marks first, followed by double quotation marks. Single quotation marks include <span class="uname" translate="no">U+300C LEFT CORNER BRACKET</span> [「] and <span class="uname" translate="no">U+300D RIGHT CORNER BRACKET</span> [」]; double quotation marks include <span class="uname" translate="no">U+300E LEFT WHITE CORNER BRACKET</span> [『] and <span class="uname" translate="no">U+300F RIGHT WHITE CORNER BRACKET</span> [』].</p>
@@ -1478,7 +1478,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">间隔号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">間隔號</span></p>
 
-            <p its-locale-filter-list="en" lang="en">Interpuncts <span class="uname" translate="no">U+00B7 MIDDLE DOT</span> [·], also known as interpoints, middots or centered dots, are punctuation marks consisting of a vertically-centered dot, and is used to separate the first name and family name in names translated from foreign languages or minorities. They are also used with book title marks to separate chapters, articles and volumes in publications.</p>
+            <p its-locale-filter-list="en" lang="en">Interpuncts <span class="uname" translate="no">U+00B7 MIDDLE DOT</span> [·], also known as interpoints, middots or centered dots, are punctuation marks consisting of a vertically-centered dot, and is used to mark divisions in transliterated foreign words. They are also used with book title marks to separate chapters, articles, and volumes in publications.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号为<span class="uname" translate="no">U+00B7 MIDDLE DOT</span> [·]。用于双书名号（书名号乙式）分隔篇、章、卷，以及外国人名中文译名、少数民族音译名，分隔姓名使用。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">間隔號為<span class="uname" translate="no">U+00B7 MIDDLE DOT</span> [·]。用於書名號乙式（雙書名號）分隔篇、章、卷，以及外國人名中文譯名、少數民族音譯名，分隔姓名使用。</p>
             <p its-locale-filter-list="en" lang="en">Interpuncts apply to Chinese only. When a translated foreign name contains a Latin character, a western period should be used rather than a interpunct. For example, <span lang="zh-hant">比尔·盖茨</span> but <span lang="zh-hant">B. 盖茨</span>.</p>
@@ -1504,7 +1504,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Book title marks are used to indicate titles of books, articles, songs, films, documents, artworks and so on.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">书名号用于标示书名、篇名、歌曲名、影剧名、文件名、字画名等各种作品名称。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">書名號用於標示書名、篇名、歌曲名、影劇名、文件名、字畫名等各種作品名稱。</p>
-            <p its-locale-filter-list="en" lang="en">According to the <cite>General Rules for Punctuation</cite> (GB/T 15834―2011), the names of books as well as chapters should be quoted using double angle brackets [《》]. When there is a need to indicate the name of another book within the double angle brackets [《》], the ordinary angle brackets [〈〉] should be used.</p>
+            <p its-locale-filter-list="en" lang="en">According to the <cite>General Rules for Punctuation</cite> (GB/T 15834―2011) in Mainland China, the names of books as well as chapters should be quoted using double angle brackets [《》]. When there is a need to indicate the name of another book within the double angle brackets [《》], the ordinary angle brackets [〈〉] should be used. Book title mark type A is only used in ancient books.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">根据中国大陆的《标点符号用法》（GB/T 15834—2011），无论书名、篇章名都应该使用双书名号[《》]，只有在书名号中还需要书名号时，里面一层用单书名号，外面一层用双书名号。甲式书名号（波浪底线）仅用于古籍。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">根據中国大陸的《标点符号用法》（GB/T 15834—2011），无论书名、篇章名都应该使用双书名号[《》]，只有在书名号中还需要书名号时，里面一层用单书名号，外面一层用双书名号。甲式書名號（波浪底線）僅用於古籍。</p>
             <p its-locale-filter-list="en" lang="en">Book title mark type B is a kind of brackets.</p>
@@ -1528,7 +1528,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans">在两个专有名词相邻时，专名号间须在视觉上分离予以辨别。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">在二個專有名詞相鄰時，專名號間須在視覺上分離予以辨別。</p>
             <div class="note" id="n029">
-              <p its-locale-filter-list="en" lang="en">As with book title marks (wavy low lines), proper noun marks is rarely used in modern publications, but it can still be seen in some textbooks and ancient publications.</p>
+              <p its-locale-filter-list="en" lang="en">As with book title mark type A (wavy low lines), proper noun marks are rarely used in modern publications, but they can still be seen in some textbooks and ancient publications.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">同甲式书名号，专名号已甚少出现于现代书籍，但仍可见于教科书或古籍的标示。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">同甲式書名號，專名號已甚少出現於現代書籍，但仍可見於教科書或古籍的標示。</p>
             </div>
@@ -4793,7 +4793,7 @@ var respecConfig = {
         <td>jiázhù fúhào</td>
         <td>brackets</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">General term for punctuation marks used within a sentence that to include additional information for clarification or for emphasis.</p>
+          <p its-locale-filter-list="en" lang="en">General term for a pair of punctuation marks isolate a segment of text from its surroundings to include additional information for clarification or for emphasis.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">为提示或突显将文本夾注起来的一类成对符号的总称。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為提示或突顯將文本夾注起來的一類成對符號的總稱。</p>
         </td>
@@ -4804,7 +4804,7 @@ var respecConfig = {
         <td>jiéshù jiázhù fúhào</td>
         <td>closing bracket(s)</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">The ending character of the paired brackets, which include quotations, parentheses, Book Title Marks etc.</p>
+          <p its-locale-filter-list="en" lang="en">The ending character of the paired brackets, which include quotation marks, parentheses, book title marks etc.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">成对的夹注符号（引号、括号、书名号）中，标注结束的字符。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">成對的夾注符號（引號、括號、書名號）中，標注結束的字元。</p>
         </td>
@@ -4848,7 +4848,7 @@ var respecConfig = {
         <td>kāishǐ jiázhù fúhào</td>
         <td>opening bracket(s)</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">The opening character of the paired brackets, which include quotations, parentheses, Book Title Marks etc.</p>
+          <p its-locale-filter-list="en" lang="en">The opening character of the paired brackets, which include quotation marks, parentheses, book title marks etc.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">成对的夹注符号（引号、括号、书名号）中，标注起始的字符。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">成對的夾注符號（引號、括號、書名號）中，標注起始的字元。</p>
         </td>

--- a/index.html
+++ b/index.html
@@ -4793,7 +4793,7 @@ var respecConfig = {
         <td>jiázhù fúhào</td>
         <td>brackets</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">General term for a pair of punctuation marks isolate a segment of text from its surroundings to include additional information for clarification or for emphasis.</p>
+          <p its-locale-filter-list="en" lang="en">General term for a pair of punctuation marks isolate a segment of text from its surroundings and include additional information for clarification or for emphasis.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">为提示或突显将文本夾注起来的一类成对符号的总称。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為提示或突顯將文本夾注起來的一類成對符號的總稱。</p>
         </td>
@@ -4804,7 +4804,7 @@ var respecConfig = {
         <td>jiéshù jiázhù fúhào</td>
         <td>closing bracket(s)</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">The ending character of the paired brackets, which include quotation marks, parentheses, book title marks etc.</p>
+          <p its-locale-filter-list="en" lang="en">The ending character of the paired brackets, which includes quotation marks, parentheses, book title marks etc.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">成对的夹注符号（引号、括号、书名号）中，标注结束的字符。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">成對的夾注符號（引號、括號、書名號）中，標注結束的字元。</p>
         </td>
@@ -4848,7 +4848,7 @@ var respecConfig = {
         <td>kāishǐ jiázhù fúhào</td>
         <td>opening bracket(s)</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">The opening character of the paired brackets, which include quotation marks, parentheses, book title marks etc.</p>
+          <p its-locale-filter-list="en" lang="en">The opening character of the paired brackets, which includes quotation marks, parentheses, book title marks etc.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">成对的夹注符号（引号、括号、书名号）中，标注起始的字符。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">成對的夾注符號（引號、括號、書名號）中，標注起始的字元。</p>
         </td>


### PR DESCRIPTION
A few changes to the English text to unify the wording a bit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/289.html" title="Last updated on Apr 23, 2020, 2:57 AM UTC (a16c97e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/289/6684fb0...a16c97e.html" title="Last updated on Apr 23, 2020, 2:57 AM UTC (a16c97e)">Diff</a>