### PR TITLE
Add links to the definition of "line gap"

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,7 +728,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">一頁的行數（分欄時為一欄的行數）</p>
         </li>
         <li id="id37">
-          <p its-locale-filter-list="en" lang="en">Line gap</p>
+          <p its-locale-filter-list="en" lang="en"><a>Line gap</a></p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行距</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行距</p>
         </li>
@@ -785,12 +785,12 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">決定版心尺寸</p>
           <ol>
             <li id="id43">
-              <p its-locale-filter-list="en" lang="en">For a document with a single column per page, specify the character size, the line length (the number of characters per line), the number of lines per page, and the line gap. </p>
+              <p its-locale-filter-list="en" lang="en">For a document with a single column per page, specify the character size, the line length (the number of characters per line), the number of lines per page, and the <a>line gap</a>. </p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">无分栏时，需决定文字尺寸、一行的字数（即行长）、一页的行数以及行距。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">無分欄時，需決定文字尺寸、一行的字數（即行長）、一頁的行數以及行距。</p>
             </li>
             <li id="id44">
-              <p its-locale-filter-list="en" lang="en">For a document with multiple columns per page, specify the character size, the line length (the number of characters per line), the number of lines per column, the line gap, the number of columns and the column gap.</p>
+              <p its-locale-filter-list="en" lang="en">For a document with multiple columns per page, specify the character size, the line length (the number of characters per line), the number of lines per column, the <a>line gap</a>, the number of columns and the column gap.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">当分栏时，需决定文字尺寸、一行的字数（即行长）、一栏的行数、行距、栏数以及栏距。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">當分欄時，需決定文字尺寸、一行的字數（即行長）、一欄的行數、行距、欄數以及欄距。</p>
             </li>
@@ -1049,16 +1049,16 @@ var respecConfig = {
           </div>
         </li>
         <li id="id53">
-          <p its-locale-filter-list="en" lang="en"> The line gaps between each line should be the same throughout the book, except for special cases. <span class="issue">It would probably help, at this point, to define what the line gap is, since it initially sounds like the same thing as line height. What are the reference points for measuring the line gap?</span></p>
+          <p its-locale-filter-list="en" lang="en"> The <a>line gaps</a> between each line should be the same throughout the book, except for special cases.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行与行之间的空白（行距）除特别状况外，需保持一致。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行與行之間的空白（行距）除特別狀況外，需保持一致。</p>
           <div class="note" id="n008">
-            <p its-locale-filter-list="en" lang="en">In Traditional Chinese composition, there are cases where pronunciation marks, referred to as 'ruby' in the <a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">Japanese Layout Requirements</a>, are inserted between lines. In such cases the line gap is not changed but kept constant. If these elements are likely to occur in the text, the line gap established during type area design needs to be of an adequate size to accommodate them.</p>
+            <p its-locale-filter-list="en" lang="en">In Traditional Chinese composition, there are cases where pronunciation marks, referred to as 'ruby' in the <a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">Japanese Layout Requirements</a>, are inserted between lines. In such cases the <a>line gap</a> is not changed but kept constant. If these elements are likely to occur in the text, the line gap established during type area design needs to be of an adequate size to accommodate them.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">繁体中文排版中，字间的注音符号可能会超入行距空间，而翻译书籍也可能使用类似日文排版的<a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">ruby</a>文字，此时行距仍需保持一致。当文中需要配置这些元素时，于设计版心的阶段就须考量到这些要素来决定行距。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">繁體中文排版中，字間的注音符號可能會超入行距空間，而翻譯書籍亦可能使用類似日文排版的<a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">ruby</a>文字，此時行距仍需保持一致。當文中需要配置這些元素時，於設計版心的階段就須考量到這些要素來決定行距。</p>
           </div>
           <div class="note" id="n009">
-            <p its-locale-filter-list="en" lang="en">The line gap for the type area is commonly set to a value between 50% and 100% of the height of the character frame used for the type area. A shorter line gap can be chosen in cases where the line length is short or the character size of the type area is relatively small. On the other hand, the line gap usually does not exceed the character size. Increasing the line gap beyond the character size does not improve the reading experience.</p>
+            <p its-locale-filter-list="en" lang="en">The <a>line gap</a> for the type area is commonly set to a value between 50% and 100% of the height of the character frame used for the type area. A shorter line gap can be chosen in cases where the line length is short or the character size of the type area is relatively small. On the other hand, the line gap usually does not exceed the character size. Increasing the line gap beyond the character size does not improve the reading experience.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">版心的行距多半介于文字尺寸的50%–100%之间，当行长较短或文字尺寸较小时，行距设定也会相对较小。反之，行距一般不会超过文字尺寸，就算超过文字尺寸，也不会因而增加易读性。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">版心的行距多半介於文字尺寸的50%–100%之間，當行長較短或文字尺寸較小時，行距設定也會相對較小。反之，行距一般不會超過文字尺寸，就算超過文字尺寸，也不會因而增加易讀性。</p>
           </div>
@@ -1073,7 +1073,7 @@ var respecConfig = {
                 <p its-locale-filter-list="zh-hant" lang="zh-hant">行高=文字尺寸÷2+行距+文字尺寸÷2=文字尺寸+行距</p>
               </li>
               <li id="id55">
-                <p its-locale-filter-list="en" lang="en">line gap = line height - character size</p>
+                <p its-locale-filter-list="en" lang="en"><dfn id="endef_lineGap">line gap</dfn> = line height - character size</p>
                 <p its-locale-filter-list="zh-hans" lang="zh-hans">行距=行高-文字尺寸</p>
                 <p its-locale-filter-list="zh-hant" lang="zh-hant">行距=行高-文字尺寸</p>
               </li>
@@ -2367,7 +2367,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans">当注音标注在基字右侧时，原则上占用文字尺寸一半的空间。该空间包含字音与调号，无调号的注音（如国语阴平调）所占的注文空间与包含调号者一致。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">當注音標注於基字右側時，原則上佔用文字尺寸一半的空間。該空間包含字音與調號，無調號的注音（如國語陰平調）所佔的注文空間與包含調號者一致。</p>
             <div class="note" id="n041">
-              <p its-locale-filter-list="en" lang="en">In vertical writing mode, when Zhuyin annotations are placed to the right side of the base characters (vertical Zhuyin), the line gap of the paragraph, where the Zhuyin annotations should be placed, needs more than 1.5 times that of the base characters. The type area should be designed to allow the proper space for the line gap. If the line gap is more than 1.5 times that of the height of the base character, the line gap should not be affected, whether there are Zhuyin annotations between the lines or not.</p>
+              <p its-locale-filter-list="en" lang="en">In vertical writing mode, when Zhuyin annotations are placed to the right side of the base characters (vertical Zhuyin), the <a>line gap</a> of the paragraph, where the Zhuyin annotations should be placed, needs more than 1.5 times that of the base characters. The type area should be designed to allow the proper space for the line gap. If the line gap is more than 1.5 times that of the height of the base character, the line gap should not be affected, whether there are Zhuyin annotations between the lines or not.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">文字直排、注音置于基字右侧时，段落通常需要基字尺寸1.5倍以上的行距，注文应标注在此行距间，设计版心时须先取适当行距值。段落行距在基字尺寸1.5倍以上时，行距不应受注音标注与否的影响。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">文字直排、注音置於基字右側時，段落通常需要基字尺寸1.5倍以上的行距，注文應標注於此行距間，設計版心時須先取適當行距值。段落行距在基字尺寸1.5倍以上時，行距不應受注音標注與否的影響。</p>
             </div>


### PR DESCRIPTION
per https://www.w3.org/2020/07/08-clreq-minutes.html#t12


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/315.html" title="Last updated on Jul 9, 2020, 6:46 AM UTC (cea530b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/315/00bbb13...cea530b.html" title="Last updated on Jul 9, 2020, 6:46 AM UTC (cea530b)">Diff</a>