### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,13 +88,10 @@ var respecConfig = {
     },
   ],
 
-  wg: "Internationalization Working Group",
-  wgURI: "https://www.w3.org/International/core/",
+  group: "i18n",
   wgPublicList: "public-i18n-cjk",
 
   github: "w3c/clreq",
-
-  wgPatentURI: "https://www.w3.org/2004/01/pp-impl/32113/status"
 };
 </script>
 </head>


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/318.html" title="Last updated on Jul 23, 2020, 3:36 AM UTC (c22a770)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/318/0603a82...c22a770.html" title="Last updated on Jul 23, 2020, 3:36 AM UTC (c22a770)">Diff</a>