### PR TITLE
Change the title

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Requirements for Chinese Text Layout 中文排版需求</title>
+<title>Requirements for Chinese Text Layout - 中文排版需求</title>
 
 <link rel="stylesheet" href="./local.css" />
 


### PR DESCRIPTION
Pubrules will convert the `<br/>` in the [h1](https://github.com/w3c/clreq/blob/3384e9a8747baa2b5b0703a0041465c528f1cdd8/index.html#L100) to ` - `, so add a ` - ` here. Otherwise, Pubrules will report an error:

>    Content of title and h1 do not match. Text of title is 'Requirements for Chinese Text Layout中文排版需求' while h1 is (transformed into) 'Requirements for Chinese Text Layout - 中文排版需求'.

/cc @r12a


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/390.html" title="Last updated on Oct 1, 2021, 6:34 AM UTC (82277cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/390/eaf765e...82277cb.html" title="Last updated on Oct 1, 2021, 6:34 AM UTC (82277cb)">Diff</a>