### PR TITLE
Fix #388

### DIFF
--- a/index.html
+++ b/index.html
@@ -1976,7 +1976,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans">绝大多数的中文出版物没有悬挂行尾点号的惯例。参考<a href="https://www.w3.org/TR/jlreq/#h-note-162">日文排版</a>的做法，点号悬挂是行首标点禁则处理方式的延伸，可以避免文字及点号在前后行的移动，甚而导致前行字距不一的问题。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">絕多數的中文出版品沒有懸掛行尾點號的慣例。參考<a href="https://www.w3.org/TR/jlreq/#h-note-162">日文排版</a>的做法，點號懸掛是行首標點禁則處理方式的延伸，可以避免文字及點號在前後行的移動，甚而導致前行字距不一的問題。</p>
       <p its-locale-filter-list="en" lang="en">In general, the punctuation marks that can be hung at the line end include slight-pause comma, comma and period. In Simplified Chinese, all the pause or stop punctuation marks overhang the line end since they are positioned at the starting point of the character frame.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">通常，行尾只可悬挂一个点号；适合行尾悬挂的点号有顿号、逗号及句号。简体中文排版中，其余点号因其字面分布偏向被标注文字的一侧、字面始端，也可进行行尾悬挂配置。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">通常，行尾只可悬挂一个点号；适合行尾悬挂的点号有顿号、逗号及句号。简体中文排版中，其余点号因其字面分布偏向被标注文字的一侧、字面始端，也可进行行尾悬挂配置。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">通常，行尾只可懸掛一個點號；適合行尾懸掛的點號有頓號、逗號及句號三者。簡體中文排版中，其餘點號因其字面分布偏向受注文字一側、字面始端，亦可進行行尾懸掛配置。</p>
       <p its-locale-filter-list="en" lang="en">If a punctuation mark (slight-pause comma, comma or period) is expected to be at the start of a line, it should be placed at the end of the previous line, to fit in the type area.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">若点号（顿号、逗号或句号）将出现于行首，可将其置于前一行的行尾端、突出版心。</p>

--- a/index.html
+++ b/index.html
@@ -1973,8 +1973,8 @@ var respecConfig = {
       </h4>
 
       <p its-locale-filter-list="en" lang="en">Most Chinese publications do not use hanging punctuation at line end. According to the <a href="https://www.w3.org/TR/jlreq/#positioning_of_punctuation_marks">Japanese Layout Requirements</a> document, hanging punctuation at the line end is a kind of extension of the prohibition rules at line start. This rule helps to avoid moving characters or punctuation marks between lines and avoids inconsistency of space between the characters in different lines.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">绝大多数的中文出版物没有悬挂行尾点号的惯例。参考<a href="https://www.w3.org/TR/jlreq/#positioning_of_punctuation_marks">日文排版</a>的做法，点号悬挂是行首标点禁则处理方式的延伸，可以避免文字及点号在前后行的移动，甚而导致前行字距不一的问题。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">絕多數的中文出版品沒有懸掛行尾點號的慣例。參考<a href="https://www.w3.org/TR/jlreq/#positioning_of_punctuation_marks">日文排版</a>的做法，點號懸掛是行首標點禁則處理方式的延伸，可以避免文字及點號在前後行的移動，甚而導致前行字距不一的問題。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">绝大多数的中文出版物没有悬挂行尾点号的惯例。参考<a href="https://www.w3.org/TR/jlreq/#h-note-162">日文排版</a>的做法，点号悬挂是行首标点禁则处理方式的延伸，可以避免文字及点号在前后行的移动，甚而导致前行字距不一的问题。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">絕多數的中文出版品沒有懸掛行尾點號的慣例。參考<a href="https://www.w3.org/TR/jlreq/#h-note-162">日文排版</a>的做法，點號懸掛是行首標點禁則處理方式的延伸，可以避免文字及點號在前後行的移動，甚而導致前行字距不一的問題。</p>
       <p its-locale-filter-list="en" lang="en">In general, the punctuation marks that can be hung at the line end include slight-pause comma, comma and period. In Simplified Chinese, all the pause or stop punctuation marks overhang the line end since they are positioned at the starting point of the character frame.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">通常，适合行尾悬挂的点号有顿号、逗号及句号。简体中文排版中，其余点号因其字面分布偏向被标注文字的一侧、字面始端，也可进行行尾悬挂配置。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">通常，適合行尾懸掛的點號有頓號、逗號及句號三者。簡體中文排版中，其餘點號因其字面分布偏向受注文字一側、字面始端，亦可進行行尾懸掛配置。</p>

--- a/index.html
+++ b/index.html
@@ -1985,8 +1985,6 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">然而，由于港台地区的点号位于字面正中，若在横排时使用行尾悬挂，体例可能显得突兀、不良，故横排时不做行尾悬挂配置；但可用于直排。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">然而，由於港台地區的點號位於字面正中，若在橫排時使用行尾懸掛，體例可能顯得突兀、不良，故橫排時不做行尾懸掛配置；但可用於直排。</p>
       <p its-locale-filter-list="en" lang="en">In the case of a succession of punctuation marks, punctuation hanging should not be applied.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">连续多个标点符号的情况下，不作行尾点号悬挂的配置。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">連續多個標點符號的情況下，不作行尾點號懸掛的配置。</p>
     </section>
 
 

--- a/index.html
+++ b/index.html
@@ -1976,8 +1976,8 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans">绝大多数的中文出版物没有悬挂行尾点号的惯例。参考<a href="https://www.w3.org/TR/jlreq/#h-note-162">日文排版</a>的做法，点号悬挂是行首标点禁则处理方式的延伸，可以避免文字及点号在前后行的移动，甚而导致前行字距不一的问题。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">絕多數的中文出版品沒有懸掛行尾點號的慣例。參考<a href="https://www.w3.org/TR/jlreq/#h-note-162">日文排版</a>的做法，點號懸掛是行首標點禁則處理方式的延伸，可以避免文字及點號在前後行的移動，甚而導致前行字距不一的問題。</p>
       <p its-locale-filter-list="en" lang="en">In general, the punctuation marks that can be hung at the line end include slight-pause comma, comma and period. In Simplified Chinese, all the pause or stop punctuation marks overhang the line end since they are positioned at the starting point of the character frame.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">通常，适合行尾悬挂的点号有顿号、逗号及句号。简体中文排版中，其余点号因其字面分布偏向被标注文字的一侧、字面始端，也可进行行尾悬挂配置。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">通常，適合行尾懸掛的點號有頓號、逗號及句號三者。簡體中文排版中，其餘點號因其字面分布偏向受注文字一側、字面始端，亦可進行行尾懸掛配置。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">通常，行尾只可悬挂一个点号；适合行尾悬挂的点号有顿号、逗号及句号。简体中文排版中，其余点号因其字面分布偏向被标注文字的一侧、字面始端，也可进行行尾悬挂配置。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">通常，行尾只可懸掛一個點號；適合行尾懸掛的點號有頓號、逗號及句號三者。簡體中文排版中，其餘點號因其字面分布偏向受注文字一側、字面始端，亦可進行行尾懸掛配置。</p>
       <p its-locale-filter-list="en" lang="en">If a punctuation mark (slight-pause comma, comma or period) is expected to be at the start of a line, it should be placed at the end of the previous line, to fit in the type area.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">若点号（顿号、逗号或句号）将出现于行首，可将其置于前一行的行尾端、突出版心。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">若點號（頓號、逗號或句號）將出現於一行之首，可將其置於前一行的行尾端、突出版心。</p>


### PR DESCRIPTION
This revision is based on the issue #388 and the discussion on the [editors’ meeting in Oct 2021](https://www.w3.org/2021/10/13-clreq-minutes.html#t05).

Changed:

* Update the reference link of “hanging punctuation” to map the latest URL of <i>JLReq</i> “hanging punctuation”–related anchor (the first note in 3.8.2).
* Revise the second paragraph of 3.1.7.
* Remove the last paragraph of 3.1.7, which is unnecessary now.
* Remove an unnecessary `checkme` class for the second paragraph of 3.1.7.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/396.html" title="Last updated on Oct 16, 2021, 5:05 PM UTC (4f5e2a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/396/7a7ca28...realfish:4f5e2a8.html" title="Last updated on Oct 16, 2021, 5:05 PM UTC (4f5e2a8)">Diff</a>