### PR TITLE
Fix #387

### DIFF
--- a/index.html
+++ b/index.html
@@ -1939,7 +1939,7 @@ var respecConfig = {
         <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號出現在一行之首或之末時，以下的空隙調整規則得以使文字體裁更加緊湊、易讀。</p>
         <ol>
           <li id="id101">
-            <p its-locale-filter-list="en" lang="en">For the case of line head indent, if an opening bracket is set at the beginning of the first line of the paragraph, half a character space can be reduced ahead of the bracket.</p>
+            <p its-locale-filter-list="en" lang="en">For the case of first-line indent, if an opening bracket is set at the beginning of the first line of the paragraph, half a character space can be reduced ahead of the bracket.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用段首缩进格式的排版中，若首行行首出现开始夹注符号，可以缩减该符号始侧二分之一个汉字大小的空白。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">使用段首縮進格式的排版中，若首行行首出現開始夾注符號，可以縮減該符號始側二分之一個漢字大小的空白。</p>
           </li>
@@ -2723,37 +2723,37 @@ var respecConfig = {
 
     <section id="line_head_indent_at_the_beginning_of_paragraphs">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Line Head Indent at the Beginning of Paragraphs</span>
+        <span its-locale-filter-list="en" lang="en" class="checkme">First-line Indents</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">段首缩排</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">段首縮排</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">A paragraph, a section of a document which consists of one or more sentences to indicate a distinct idea, usually begins on a new line. For the related line head indent at the beginning of paragraphs, the following methods are available.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">A paragraph, a section of a document which consists of one or more sentences to indicate a distinct idea, usually begins on a new line. For the related first-line indents, the following methods are available.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">为使不同的文本形成意义上的区隔、构成段落，呈现上，会使用断行以标示一个段落的起始，同时也会在段落首行加上空白进行缩排（也称为缩进），原则上以文本的汉字大小作为缩排单位，主要呈现方法如下。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">為使不同的文本形成意義上的區隔、構成段落，呈現上，會使用斷行以標示一個段落的起始，同時也會在段落首行加上空白進行縮排（也稱為縮進），原則上以文本的漢字大小作為縮排單位，主要呈現方法如下。</p>
       <div class="note" id="n046">
-        <p its-locale-filter-list="en" lang="en">For Chinese publications, line head indent at the beginning of a paragraph usually uses two character width spaces. Publications like magazines, with multi-column content and less text in each column, might apply a single character width line head indent at the beginning of paragraph as well.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">For Chinese publications, a first-line indent usually uses two character width spaces. Publications like magazines, with multi-column content and less text in each column, might apply single character width first-line indents as well.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">中文出版品上，段首缩排以两个汉字的空间为标准。若遇到杂志等多栏排版的情况，每栏字数较少时，视觉上缩排两字将显突兀，时有改用缩排一字的做法。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">中文出版品上，段首縮排以兩個漢字的空間為標準。若遇到雜誌等多欄排版的情況，每欄字數較少時，視覺上縮排兩字將顯突兀，時有改用縮排一字的做法。</p>
       </div>
       <ol>
         <li id="id154">
-          <p its-locale-filter-list="en" lang="en">Line head indent at the beginning of a paragraph is applied to all paragraphs. Nearly all books and magazines make use of this method.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">First-line indents are applied to all paragraphs. Nearly all books and magazines make use of this method.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">所有段落首行皆缩排。几乎所有的书籍与杂志皆使用此方法。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">所有段落首行皆縮排。幾乎所有的書籍與雜誌皆使用此方法。</p>
         </li>
         <li id="id155">
-          <p its-locale-filter-list="en" lang="en">Line head indent does not apply to the first paragraph but to the rest of the paragraphs. This method is mostly seen in Western publications.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">First-line indents do not apply to the first paragraph but to the rest of the paragraphs. This method is mostly seen in Western publications.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">篇章最初段落的首行不缩排，其余段落首行缩排。此方法多见于西文书籍。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">篇章最初段落的首行不縮排，其餘段落首行縮排。此方法多見於西文書籍。</p>
         </li>
         <li id="id156">
-          <p its-locale-filter-list="en" lang="en">Line head indent at the beginning of a paragraph is not applied for any paragraph at all. A certain amount of space is inserted between the paragraphs so as to indicate the distinction between different paragraphs. In some books and magazines this method is applied.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">No first-line indent is applied to any paragraph. A certain amount of space is inserted between the paragraphs so as to indicate the distinction between different paragraphs. In some books and magazines this method is applied.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">所有段落首行皆不缩排，在段落与段落间加入一定程度的间距，作为间隔。部分书籍与杂志使用这种方式。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">所有段落首行皆不予縮排，在段落與段落間加入一定程度的間距，以為區隔。部分書籍與雜誌使用這種方式。</p>
         </li>
         <li id="id157">
-          <p its-locale-filter-list="en" lang="en">In principle, some unfinished paragraphs should be broken rather than apply the line head indent for the following paragraph. Dialogs, quotations or subtitles that the editor inserted might appear before the unfinished paragraph.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">In principle, some unfinished paragraphs should be broken rather than apply the first-line indents for the following paragraph. Dialogs, quotations or subtitles that the editor inserted might appear before the unfinished paragraph.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">原则上，部分语气未完的段落予以断行、而不缩排。语气未完的段落前可能出现对话、引言以及为与正文有所区隔，由编辑所下的标题等。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">原則上，部分語氣未完的段落予以斷行、而不縮排。語氣未完的段落前可能出現對話、引言，及為與正文有所區隔，由編輯所下的標題等。</p>
         </li>

--- a/index.html
+++ b/index.html
@@ -2721,7 +2721,7 @@ var respecConfig = {
       <span its-locale-filter-list="zh-hant" lang="zh-hant">段落調整</span>
     </h3>
 
-    <section id="line_head_indent_at_the_beginning_of_paragraphs">
+    <section id="first_line_indents">
       <h4>
         <span its-locale-filter-list="en" lang="en" class="checkme">First-line Indents</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">段首缩排</span>

--- a/index.html
+++ b/index.html
@@ -2727,6 +2727,8 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hans" lang="zh-hans">段首缩排</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">段首縮排</span>
       </h4>
+      <!-- Old `id` of the section 段首缩排/段首縮排 -->
+      <span id="line_head_indent_at_the_beginning_of_paragraphs"></span>
 
       <p its-locale-filter-list="en" lang="en" class="checkme">A paragraph, a section of a document which consists of one or more sentences to indicate a distinct idea, usually begins on a new line. For the related first-line indents, the following methods are available.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">为使不同的文本形成意义上的区隔、构成段落，呈现上，会使用断行以标示一个段落的起始，同时也会在段落首行加上空白进行缩排（也称为缩进），原则上以文本的汉字大小作为缩排单位，主要呈现方法如下。</p>


### PR DESCRIPTION
This revision is based on the issue #387 and the discussion on the [editors’ meeting in Oct 2021](https://www.w3.org/2021/10/13-clreq-minutes.html#t06).

Changed:

* Change the term “line head indent at the beginning of paragraph(s)” into “first-line indent(s)”.
* Grammatically revise some singular/plural forms for related copy (**review needed**).
* Update the section `id` string of 3.4.1.
* Make the old anchor link to the 3.4.1 section a cool URI.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/397.html" title="Last updated on Oct 19, 2021, 6:54 PM UTC (42d8688)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/397/7a7ca28...realfish:42d8688.html" title="Last updated on Oct 19, 2021, 6:54 PM UTC (42d8688)">Diff</a>