### PR TITLE
Fix lang switcher overflowing on mobile issue

### DIFF
--- a/local.css
+++ b/local.css
@@ -180,6 +180,8 @@ code { color: #A52A2A; }
   font-weight: bold;
 }
 
+.appendix { overflow-x: scroll }
+
 table { border-collapse: collapse; }
 table tr { border-bottom: 1px solid #ddd; }
 table th { padding: .25em .25em .5em .25em; }


### PR DESCRIPTION
Closes https://github.com/w3c/clreq/issues/414

This PR sets the sections containing tables in the appendix to scroll horizontally so the language switcher's `position: fixed` falls within the width of the viewport.
Tested on mobile Firefox and Chrome.