### PR TITLE
Switch the language of the title

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ var LANG_LIST = ['en', 'zh-hant', 'zh-hans']
 var L10N = {
 	'en': {
     selector: {
+      'head > title': 'Requirements for Chinese Text Layout',
       '#abstract > h2': 'Abstract',
       '#sotd > h2': 'Status of This Document',
       '#table-of-contents': 'Table of Contents',
@@ -22,6 +23,7 @@ var L10N = {
 
   'zh-hant': {
     selector: {
+      'head > title': '中文排版需求',
       '#abstract > h2': '摘要',
       '#sotd > h2': '關於本文檔',
       '#table-of-contents': '內容大綱',
@@ -51,6 +53,7 @@ var L10N = {
 
   'zh-hans': {
     selector: {
+      'head > title': '中文排版需求',
       '#abstract > h2': '摘要',
       '#sotd > h2': '关于本文档',
       '#table-of-contents': '内容大纲',


### PR DESCRIPTION
Currently, the title of the document (as displayed on the browser tab) will not change after switching languages, but there is one problem: the English title is relatively long. In many cases, I don't know what this tab contains by just looking at the title on the browser tab. I think it would be much better if it could be displayed in Chinese, since it's shorter.

See the screenshots below for comparison:

<img width="185" alt="en" src="https://user-images.githubusercontent.com/2863444/148034148-f0fa491b-5ede-404a-ac33-7c1c9b9ba8d7.png"> <img width="180" alt="zh" src="https://user-images.githubusercontent.com/2863444/148034162-6b692f3c-1ef0-4568-bb78-efe157b4c2b1.png">

Note: the title will only be displayed in Chinese when the document is switched to Traditional/Simplified Chinese.