### PR TITLE
Use W3C Software and Document license

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,4 +1,4 @@
 All documents in this Repository are licensed by contributors
 under the 
-[W3C Document License](http://www.w3.org/Consortium/Legal/copyright-documents).
+[W3C Software and Document license](https://www.w3.org/Consortium/Legal/copyright-software).
 


### PR DESCRIPTION
I noticed that the LICENCE.md of lreq documents use the *Document* license, but the i18n [WG](https://www.w3.org/International/groups/wg/charter.html#licensing)/[IG](https://www.w3.org/International/groups/ig/charter.html#licensing) charters and the documents use the *Software and Document* license (which is a similar but different license). I believe we should use the license in the charter, so the LICENCE.md should be updated.
