### PR TITLE
Fix vocabulary differences between regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,15 @@ The following information describes work going on at the W3C to support language
 - [Internationalization Sponsorship Program](https://www.w3.org/International/sponsorship/)
 
 
-### Links for editors
+### Links for editors 编辑用链接
 If you end up creating a document, you should be familiar with and use the following:
+
+如果您成为了小组文档的编辑，您应该熟悉以下内容：
 
 **Because the document is multilingual, you need to follow certain steps when creating or modifying the source text. See [EDITING.md](https://w3c.github.io/clreq/EDITING) for details.**
 
-- [Github guidelines for working with i18n documents](https://www.w3.org/International/i18n-activity/guidelines/github)
+**由于文档包含多种语言，您在创建或修改源代码时需要遵循特定步骤。 有关详细信息，请参阅[EDITING.md](https://w3c.github.io/clreq/EDITING)。**
+
+- [GitHub guidelines for working with i18n documents](https://www.w3.org/International/i18n-activity/guidelines/github)
 - [Editorial guidelines for working with i18n documents](https://www.w3.org/International/i18n-activity/guidelines/editing)
+- [工作組編輯體例之簡繁體詞彙表](https://github.com/w3c/clreq/wiki/%E5%B7%A5%E4%BD%9C%E7%B5%84%E7%B7%A8%E8%BC%AF%E9%AB%94%E4%BE%8B%E4%B9%8B%E7%B0%A1%E7%B9%81%E9%AB%94%E8%A9%9E%E5%BD%99%E8%A1%A8)

--- a/index.html
+++ b/index.html
@@ -2821,7 +2821,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">除縮排外，也有首行不縮排、次行起至末行縮排的狀況，稱為凸排。例如劇本中的對白，首行以人名開頭不縮排，第二行起縮排。編號列表、問答、法律條文等也使用此種方式處理。雖稱為凸排，但首行開始處不超過版心所設定的範圍。</p>
       <p its-locale-filter-list="en" lang="en">When the tupai [<span lang="zh-hant">凸排</span>] or itemization method is used, the indent of the second line and the rest usually takes a fixed amount of space such as three characters plus one colon which takes four-character space. When the name of a person is less than three characters, a certain amount of space should be inserted between the characters so as to keep the same width as four.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">凸排时，次行起缩排通常为固定量的空白，例如人名三个字加冒号共四字，凡遇对话时次行皆缩排四个全角空白。当人名少于三个字时，则在姓与名间加入空白，以保持体例一致。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">凸排時，次行起縮排通常為固定量的空白，例如人名三字加冒號共四字，凡遇對話時次行皆縮排四個全型空白。遇人名少於三字時，則於姓與名間加入空白，以保持體例一致。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">凸排時，次行起縮排通常為固定量的空白，例如人名三字加冒號共四字，凡遇對話時次行皆縮排四個全形空白。遇人名少於三字時，則於姓與名間加入空白，以保持體例一致。</p>
     </section>
 
 
@@ -3212,7 +3212,7 @@ var respecConfig = {
               行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定「5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。」
             </p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-              行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全角字符則應占半角字符的寬度（即半個字位置），以使視覺效果更美觀。」
+              行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全形字符則應占半形字符的寬度（即半個字位置），以使視覺效果更美觀。」
             </p>
           </aside>
         </li>
@@ -4712,7 +4712,7 @@ var respecConfig = {
             <li id="id206">A square character frame that has a character advance of 1/2 character size.
           </ol>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">排字的度量单位，宽度等于同样字号全角的一半。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">排字的度量單位，寬度等於同樣字號全角的一半。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">排字的度量單位，寬度等於同樣字號全形的一半。</p>
         </td>
       </tr>
       <tr id="term.punctuation-marks">

--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@ var respecConfig = {
     <p its-locale-filter-list="zh-hans" lang="zh-hans">每一个文化群体都拥有独自的语言、文字、书写系统。将个别书写系统在虚拟空间再现，对文化资产的承继而言，是信息传播技术的重要责任。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">每一個文化群體都擁有獨自的語言、文字、書寫系統。將個別書寫系統在虛擬空間再現，對文化資產的承繼而言，是資訊傳播技術的重要責任。</p>
     <p its-locale-filter-list="en" lang="en">As one of the basic work items of this task force, this document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondences with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">作为实现这个责任的基础，本文整理了中文（汉字）书写系统在排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提供与既有标准（如Unicode）的对应，冀求透过本文有效地促进实现。</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">作为实现这个责任的基础，本文整理了中文（汉字）书写系统在排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提供与既有标准（如Unicode）的对应，冀求通过本文有效地促进实现。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">作為實現這個責任的基礎，本文整理了中文（漢字）書寫系統在排版上的需求。一方面說明需求事項以明確描述中文排版之需求與問題；另一方面也提供與既有標準（如Unicode）的對應，冀求透過本文有效地促進實作。</p>
   </section>
 
@@ -1410,7 +1410,7 @@ var respecConfig = {
 
             <div class="note" id="n022">
               <p its-locale-filter-list="en" lang="en">There are vertical bracket codepoints such as <span class="uname" translate="no">U+FE41 PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET</span> in Unicode. But they are not suitable for authors to use directly. They should be replaced via some other mechanism.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">Unicode编码中有如<span class="uname" translate="no">U+FE41 PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET</span>等直立的符号，但作者不适宜直接使用该符号，而是透过其他机制替代使用。</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">Unicode编码中有如<span class="uname" translate="no">U+FE41 PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET</span>等直立的符号，但作者不适宜直接使用该符号，而是通过其他机制替代使用。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">Unicode編碼中有如<span class="uname" translate="no">U+FE41 PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET</span>等直立的符號，但作者不適宜直接使用該符號，而是透過其他機制替代使用。</p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -1665,7 +1665,7 @@ var respecConfig = {
         <p its-locale-filter-list="zh-hant" lang="zh-hant">排版上，《標點符號用法》規定問號與嘆號連用時，佔一個字位置；兩個問號或嘆號疊用時，佔一個字位置；三個問號或嘆號疊用時，佔兩個字位置。此外，在台灣直排的習慣中，嘆問號連用與問號、嘆號疊用時，符號多直立，並且佔一個字的位置。</p>
         <div class="note">
           <p its-locale-filter-list="en" lang="en">The following punctuation marks already exist in Unicode: U+2047 DOUBLE QUESTION MARK [⁇]、U+203C DOUBLE EXCLAMATION MARK [‼ ]、U+2048 QUESTION EXCLAMATION MARK [⁈]、U+2049 EXCLAMATION QUESTION MARK [⁉]. They should be used with discretion.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">在Unicode中已编有U+2047 DOUBLE QUESTION MARK [⁇]、U+203C DOUBLE EXCLAMATION MARK [‼ ]、U+2048 QUESTION EXCLAMATION MARK [⁈]、U+2049 EXCLAMATION QUESTION MARK [⁉]等符号，在考量字体支援下可斟酌使用。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">在Unicode中已编有U+2047 DOUBLE QUESTION MARK [⁇]、U+203C DOUBLE EXCLAMATION MARK [‼ ]、U+2048 QUESTION EXCLAMATION MARK [⁈]、U+2049 EXCLAMATION QUESTION MARK [⁉]等符号，在考量字体支持下可斟酌使用。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">在Unicode中已編有U+2047 DOUBLE QUESTION MARK [⁇]、U+203C DOUBLE EXCLAMATION MARK [‼]、U+2048 QUESTION EXCLAMATION MARK [⁈]、U+2049 EXCLAMATION QUESTION MARK [⁉]等符號，在考量字體支援下可斟酌使用。</p>
         </div>
       </section>


### PR DESCRIPTION
And add a link to [工作組編輯體例之簡繁體詞彙表](https://github.com/w3c/clreq/wiki/%E5%B7%A5%E4%BD%9C%E7%B5%84%E7%B7%A8%E8%BC%AF%E9%AB%94%E4%BE%8B%E4%B9%8B%E7%B0%A1%E7%B9%81%E9%AB%94%E8%A9%9E%E5%BD%99%E8%A1%A8) per https://www.w3.org/2022/01/21-clreq-minutes.html#t10

Fix #391 and #434.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/438.html" title="Last updated on Jan 24, 2022, 2:18 PM UTC (4d9dc07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/438/b5d6660...4d9dc07.html" title="Last updated on Jan 24, 2022, 2:18 PM UTC (4d9dc07)">Diff</a>