### PR TITLE
Add Unicode to the References section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5571,8 +5571,9 @@ var respecConfig = {
     <li>《标点符号用法》— General Rules for Punctuation (GB/T 15834—2011)</li>
     <li>《出版物上数字用法》— General Rules for writing numerals in public texts (GB/T 15835—2011)</li>
     <li>《國語注音符號手冊》— The Handbook of Mandarin Phonetic Symbols</li>
-    <li>《汉语拼音正词法基本规则》— Basic Rules for Chinese Phonetic Alphabet Orthography（GB/T 16159—2012）</li>
-    <li>《党政机关公文格式》— Layout key for official document of Party and government organs（GB/T 9704—2012）</li>
+    <li>《汉语拼音正词法基本规则》— Basic Rules for Chinese Phonetic Alphabet Orthography (GB/T 16159—2012)</li>
+    <li>《党政机关公文格式》— Layout key for official document of Party and government organs (GB/T 9704—2012)</li>
+    <li><a href="https://www.unicode.org/versions/latest/">The Unicode Standard</a></li>
   </ul>
 </section>
 


### PR DESCRIPTION
Fix #428.

By the way, I fixed the parentheses in the last two lines (changing the full-width parentheses in English to half-width).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/439.html" title="Last updated on Jan 24, 2022, 1:43 PM UTC (529ac41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/439/b5d6660...529ac41.html" title="Last updated on Jan 24, 2022, 1:43 PM UTC (529ac41)">Diff</a>