### PR TITLE
Rearrange table headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3673,18 +3673,18 @@ var respecConfig = {
         <tr>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (TC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（繁）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
           </th>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (SC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（简）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
           </th>
           <th class="character">
             <span its-locale-filter-list="en" lang="en">Character</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">字符</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
           </th>
           <th class="unicode">
             <span its-locale-filter-list="en" lang="en">Unicode</span>
@@ -3693,13 +3693,13 @@ var respecConfig = {
           </th>
           <th class="unicode-name">
             <span its-locale-filter-list="en" lang="en">Name</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">Unicode名称</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
           </th>
           <th>
             <span its-locale-filter-list="en" lang="en">Note</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">注</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">注</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">注</span>
           </th>
         </tr>
       </thead>
@@ -3819,18 +3819,18 @@ var respecConfig = {
         <tr>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (TC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（繁）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
           </th>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (SC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（简）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
           </th>
           <th class="character">
             <span its-locale-filter-list="en" lang="en">Character</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">字符</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
           </th>
           <th class="unicode">
             <span its-locale-filter-list="en" lang="en">Unicode</span>
@@ -3839,13 +3839,13 @@ var respecConfig = {
           </th>
           <th class="unicode-name">
             <span its-locale-filter-list="en" lang="en">Name</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">Unicode名称</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
           </th>
           <th>
             <span its-locale-filter-list="en" lang="en">Note</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">注</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">注</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">注</span>
           </th>
         </tr>
       </thead>
@@ -3973,18 +3973,18 @@ var respecConfig = {
         <tr>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (TC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（繁）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
           </th>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (SC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（简）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
           </th>
           <th class="character">
             <span its-locale-filter-list="en" lang="en">Character</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">字符</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
           </th>
           <th class="unicode">
             <span its-locale-filter-list="en" lang="en">Unicode</span>
@@ -3993,13 +3993,13 @@ var respecConfig = {
           </th>
           <th class="unicode-name">
             <span its-locale-filter-list="en" lang="en">Name</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">Unicode名称</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
           </th>
           <th>
             <span its-locale-filter-list="en" lang="en">Note</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">注</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">注</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">注</span>
           </th>
         </tr>
       </thead>
@@ -4172,18 +4172,18 @@ var respecConfig = {
         <tr>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (TC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（繁）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（繁）</span>
           </th>
           <th class="name">
             <span its-locale-filter-list="en" lang="en">Name (SC)</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">名称（简）</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">名稱（簡）</span>
           </th>
           <th class="character">
             <span its-locale-filter-list="en" lang="en">Character</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">字符</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
           </th>
           <th class="unicode">
             <span its-locale-filter-list="en" lang="en">Unicode</span>
@@ -4192,8 +4192,8 @@ var respecConfig = {
           </th>
           <th class="unicode-name">
             <span its-locale-filter-list="en" lang="en">Name</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">Unicode名称</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
           </th>
         </tr>
       </thead>
@@ -4249,8 +4249,8 @@ var respecConfig = {
         <tr>
           <th class="character">
             <span its-locale-filter-list="en" lang="en">Character</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">字符</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">字符</span>
           </th>
           <th class="unicode">
             <span its-locale-filter-list="en" lang="en">Unicode</span>
@@ -4259,18 +4259,18 @@ var respecConfig = {
           </th>
           <th class="unicode-name">
             <span its-locale-filter-list="en" lang="en">Name</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">Unicode名称</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">Unicode名稱</span>
           </th>
           <th class="true-or-false">
             <span its-locale-filter-list="en" lang="en">Unbreakable</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">不可分離</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">不可分离</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">不可分離</span>
           </th>
           <th class="true-or-false">
             <span its-locale-filter-list="en" lang="en">Rotated 90° clockwise in vertical writing mode</span>
-            <span its-locale-filter-list="zh-hant" lang="zh-hant">直排時右旋90°</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">直排时右旋90°</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">直排時右旋90°</span>
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
Rearrange the table headers so that each line is of the same type for easy reading.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jzhangdev/clreq/pull/441.html" title="Last updated on Jan 25, 2022, 3:05 AM UTC (5c5f3e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/441/b5d6660...jzhangdev:5c5f3e1.html" title="Last updated on Jan 25, 2022, 3:05 AM UTC (5c5f3e1)">Diff</a>