### PR TITLE
Keep character usage uniform

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ var respecConfig = {
     <ol>
       <li id="id3">
         <p its-locale-filter-list="en" lang="en">The Chinese writing system can be broadly classified into either Traditional Chinese or Simplified Chinese. Chinese communities in different regions (e.g. Mainland China, Taiwan, Hong Kong, Macau, Singapore, Malaysia etc.) may have their own regional standards. These differ with respect to which glyph represents a canonical vs. a variant shape, or how many strokes are contained in a given character. They may also have typographic layout rules specific to their own region.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">中文的书写系统可以大致分为「繁体字」「简体字」系统，但是，使用中文的各个地区（中国大陆、台湾、香港、澳门、新加坡、马来西亚等）对汉字各自分别有不同的规范化形式，其具体字形、笔画多少存在差异，也会采用与其他地区不尽相同的排版规则。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">中文的书写系统可以大致分为“繁体字”“简体字”系统，但是，使用中文的各个地区（中国大陆、台湾、香港、澳门、新加坡、马来西亚等）对汉字各自分别有不同的规范化形式，其具体字形、笔画多少存在差异，也会采用与其他地区不尽相同的排版规则。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">中文的書寫系統可以大致分為「繁體字」「簡體字」系統，但是，使用中文的各個地區（中國大陸、台灣、香港、澳門、新加坡、馬來西亞等）對漢字各自分別有不同的規範化形式，其具體字形、筆劃多少存在差異，也會採用與其他地區不盡相同的排版規則。</p>
       </li>
       <li id="id4">
@@ -164,7 +164,7 @@ var respecConfig = {
     </ol>
 	      <div class="note">
           <p its-locale-filter-list="en" lang="en">For most of the typographic rules described in this document, "regional differences" are more than "differences between Simplified and Traditional Chinese". For example, although most publications in Mainland China use Simplified Chinese characters in horizontal writing mode, a few publications use Traditional Chinese characters in horizontal or vertical writing mode, or Simplified characters in vertical writing mode. The typographical rules in Mainland China, such as the punctuation position rules specified in <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) also apply to vertical or Traditional Chinese publications published in Mainland China. For vertical and Traditional Chinese publications published in Taiwan, Taiwan's typographic rules are used. Therefore, it is recommended that the user agents distinguish typographical rules by "region" rather than "Traditional or Simplified".</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">对于本文叙述重点的排版规则来说，「地区差异」大于「繁简差异」。比如，虽然中国大陆的大多数出版物均采用简体字、横排，但仍有少数采用繁体字横排、直排或者简体字直排；中国大陆的排版规则，如 GB/T 15834—2011《标点符号用法》中规定的标点符号位置同时也适用于中国大陆出版的直排、繁体字出版物。而台湾出版的直排、繁体字出版物则采用台湾的排版规则。因此建议各种用户代理处理排版规则时，应通过「区域」设置，而非「繁简」文本设置进行区分。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">对于本文叙述重点的排版规则来说，“地区差异”大于“繁简差异”。比如，虽然中国大陆的大多数出版物均采用简体字、横排，但仍有少数采用繁体字横排、直排或者简体字直排；中国大陆的排版规则，如 GB/T 15834—2011《标点符号用法》中规定的标点符号位置同时也适用于中国大陆出版的直排、繁体字出版物。而台湾出版的直排、繁体字出版物则采用台湾的排版规则。因此建议各种用户代理处理排版规则时，应通过“区域”设置，而非“繁简”文本设置进行区分。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">對於本文敘述重點的排版規則來說，「地區差異」大於「繁簡差異」。比如，雖然中國大陸的大多數出版物均採用簡體字、橫排，但仍有少數採用繁體字橫排、直排或者簡體字直排；中國大陸的排版規則，如 GB/T 15834—2011《標點符號用法》中規定的標點符號位置同時也適用於中國大陸出版的直排、繁體字出版物。而臺灣出版的直排、繁體字出版物則採用臺灣的排版規則。因此建議各種用戶代理處理排版規則時，應通過「區域」設置，而非「繁簡」文本設置進行區分。</p>
          </div>
   </section>
@@ -300,8 +300,8 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版主要使用的文字为汉字。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版主要使用的文字為漢字。</p>
       <p its-locale-filter-list="en" lang="en">Chinese characters include Traditional Chinese and Simplified Chinese alternatives. The former is commonly used in Taiwan, Hong Kong and Macao while the latter is commonly used in Mainland China, Singapore and Malaysia.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">依照各地的通行标准，中文所使用的汉字主要分为繁体字与简体字。前者又称正体字、传统汉字等，主要通行于台湾、香港、澳门等地；后者又作简化字，主要通行于中国大陆、新马地区。本文依笔画多寡与部件结构为区别，统称为繁体字与简体字。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">依照各地的通行標準，中文所使用的漢字主要分為繁體字與簡體字。前者又作正體字、傳統漢字等，主要通行於台灣、香港、澳門等地；後者又作簡化字，主要通行於中國大陸、星馬地區。本文依筆畫多寡與部件結構為區別，統稱為繁體字與簡體字。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">依照各地的通行标准，中文所使用的汉字主要分为繁体字与简体字。前者又称正体字、传统汉字等，主要通行于台湾、香港、澳门等地；后者又作简化字，主要通行于中国大陆、新马地区。本文依笔画多寡与部件结构为区别，分别称为繁体字与简体字。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">依照各地的通行標準，中文所使用的漢字主要分為繁體字與簡體字。前者又作正體字、傳統漢字等，主要通行於台灣、香港、澳門等地；後者又作簡化字，主要通行於中國大陸、星馬地區。本文依筆畫多寡與部件結構為區別，分別稱為繁體字與簡體字。</p>
       <p its-locale-filter-list="en" lang="en">Different glyphs are used in different regions. One Unicode code point of a Chinese character may have more than one valid glyph, depending on operating system and typeface used. The focus of this document is Chinese composition and will not cover glyph variations in detail.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">不同地区所使用的字形有差异，各种字形与Unicode码位并非一一对应关系，需要依赖处理系统和字体来呈现。本文主要探究中文排版，对此不做详述。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">不同地區所使用的字形有差異，各種字形與Unicode碼位並非一一對應關係，需要依賴處理系統和字體來呈現。本文主要探究中文排版，對此不做詳述。</p>
@@ -311,7 +311,7 @@ var respecConfig = {
 
       <div class="note" id="n002">
         <p its-locale-filter-list="en" lang="en">One Simplified Chinese character may have more than one corresponding Traditional form. For example, the Simplified Chinese character <span lang="zh-hans">发</span> can be mapped to either the Traditional Chinese character <span lang="zh-hant">發</span> or <span lang="zh-hant">髮</span>. By contrast, the circumstances where one Traditional Chinese character corresponds to more than one Simplified Chinese character are fairly rare but still worth noting. For example, the Traditional Chinese character <span lang="zh-hant">乾</span> may be mapped to either the Simplified Chinese character <span lang="zh-hans">干</span> or <span lang="zh-hans">乾</span>. The mapping relationship between Traditional and Simplified Chinese is not one-to-one and particular character conversion depends on its context.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">一个简体字可能对应多个繁体字，如简体字「<span lang="zh-hans">发</span>」，其相应的繁体字可能为「<span lang="zh-hant">發</span>」或「<span lang="zh-hant">髮</span>」；一个繁体汉字对应多个简体汉字的情况与前者相比数量极少但仍需注意，如繁体字「<span lang="zh-hant">乾</span>」可能对应简体字「<span lang="zh-hans">干</span>」或「<span lang="zh-hans">乾</span>」。繁简汉字的对应关系具体应由上下文决定。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">一个简体字可能对应多个繁体字，如简体字“<span lang="zh-hans">发</span>”，其相应的繁体字可能为“<span lang="zh-hant">發</span>”或“<span lang="zh-hant">髮</span>”；一个繁体汉字对应多个简体汉字的情况与前者相比数量极少但仍需注意，如繁体字“<span lang="zh-hant">乾</span>”可能对应简体字“<span lang="zh-hans">干</span>”或“<span lang="zh-hans">乾</span>”。繁简汉字的对应关系具体应由上下文决定。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">一個簡體字可能對應多個繁體字，如簡體字「<span lang="zh-hans">发</span>」，其相應的繁體字可能為「<span lang="zh-hant">發</span>」或「<span lang="zh-hant">髮</span>」；一個繁體漢字對應多個簡體漢字的情況與前者相比數量極少但仍需注意，如繁體字「<span lang="zh-hant">乾</span>」可能對應簡體字「<span lang="zh-hans">干</span>」或「<span lang="zh-hans">乾</span>」。繁簡漢字的對應關係具體應由上下文決定。</p>
       </div>
     </section>
@@ -388,7 +388,7 @@ var respecConfig = {
           </li>
           <li id="id17">
             <p its-locale-filter-list="en" lang="en">For publications whose main audience is children, inter-character spacing is increased to make it easier for them to read.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">针对儿童书籍等，为提升易读性，而加大字距。</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">针对儿童书籍等，为提高易读性，而加大字距。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">針對兒童書籍等，為提升易讀性，而加大字距。</p>
           </li>
         </ol>
@@ -757,7 +757,7 @@ var respecConfig = {
 
       <p its-locale-filter-list="en" lang="en" class="checkme">This section explains how to create an actual page format based on the type area. </p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">本部分说明如何以基本版式为起点来为实际的各页面确定版式，这个步骤称做具体页面的“定版”。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本部分說明如何以基本版式為起點來為實際的各頁面確定版式，這個步驟稱做具體頁面的“定版”。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本部分說明如何以基本版式為起點來為實際的各頁面確定版式，這個步驟稱做具體頁面的「定版」。</p>
       <ol>
         <li id="id39">
           <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Realm and position of headings:</span> The spacing of the heading in the block direction (i.e., height of the heading in horizontal writing mode or width of the heading in vertical writing mode) should be calculated from the position of the body text, and set to a multiple of the number of lines. If indent of the heading space is required, the starting point should be from the body text position set by the type area, and the amount of indent should be a multiple of the body text size.</p>
@@ -857,11 +857,11 @@ var respecConfig = {
         </li>
         <li id="id51">
           <p its-locale-filter-list="en" lang="en">There have been different size systems for Chinese characters. The size system in traditional metal type utilized hào (literally number) units, while in the phototypesetting era, Q was used as the sizing unit instead. When it came to desktop publishing, font sizes were determined by the DTP point system which was built into the software itself. Currently, the traditional hào-system is still used for typesetting in many Chinese publications.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">中文活字大小有不同单位。在金属活字时代，传统中文活字尺寸以「号」为单位，故称作「字号」；在照相排版时代沿用照排机尺寸的单位「级」，故称作「字级」；在桌面排版时代，直接使用桌面排版软件中的「点」（DTP point）。目前，很多场合的中文排版依旧习惯沿用「号」。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">中文活字大小有不同单位。在金属活字时代，传统中文活字尺寸以“号”为单位，故称作“字号”；在照相排版时代沿用照排机尺寸的单位“级”，故称作“字级”；在桌面排版时代，直接使用桌面排版软件中的“点”（DTP point）。目前，很多场合的中文排版依旧习惯沿用“号”。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">中文活字大小有不同單位。在金屬活字時代，傳統中文活字尺寸以「號」為單位，故稱作「字號」；在照相排版時代沿用照排機尺寸的單位「級」，故稱作「字級」；在桌面排版時代，直接使用桌面排版軟件中的「點」（DTP point）。目前，很多場合的中文排版依舊習慣沿用「號」。</p>
 
           <p its-locale-filter-list="en" lang="en">These hào-systems were not standardized by the various foundries in the past. In addition, point-systems were also different in Anglo-American point systems, Europe Continental point systems, DTP point systems and other systems, which resulted in numerous conversion methods between the hào-system and the point-system. The following table lists their most common corresponding conversions as a reference. It is not normative information.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">「号」由于当年金属活字各地厂家的规范不一而不尽相同，「号」也有英美、欧陆、DTP等多种制式，导致「号」与「点」的换算有不同方法。下表仅列出常见的一些换算数值，仅供参考，不作为规范性规定：</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">“号”由于当年金属活字各地厂家的规范不一而不尽相同，“号”也有英美、欧陆、DTP等多种制式，导致“号”与“点”的换算有不同方法。下表仅列出常见的一些换算数值，仅供参考，不作为规范性规定：</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">「號」由於當年金屬活字各地廠家的規範不一而不盡相同，「號」也有英美、歐陸、DTP等多種制式，導致「號」與「點」的換算有不同方法。下表僅列出常見的一些換算數值，僅供參考，不作為規範性規定：</p>
 
           <table class="charsize" its-locale-filter-list="en" lang="en">
@@ -1303,13 +1303,13 @@ var respecConfig = {
                 <p its-locale-filter-list="en" lang="en" class="checkme">
                     In different regions, the arrangement direction of cells described by <i>row</i> (Chinese: 行 <i>háng</i>) and <i>column</i> (Chinese: 列 <i>liè</i>) in Chinese terminology may be different. For example, 行 in mainland China usually refers to a horizontal arrangement of cells, and 列 refers to a vertical arrangement of cells; while 行 in Taiwan and Hong Kong usually refers to a vertical arrangement of cells, and 列 (or 栏) refers to a horizontal arrangement of cells.
                   </p>
-                  <p its-locale-filter-list="zh-hans" lang="zh-hans">在不同的地区，中文术语中的「行」（háng）和「列」（liè）所描述的单元格排列方向，可能是不同的。例如，中国大陆的「行」通常指一组水平排列的单元格，「列」指一组垂直排列的单元格；而台湾、香港地区的「行」通常指一组垂直排列的单元格，「列」（或「栏」）指一组水平排列的单元格。</p>
-                  <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">在不同的地區，中文術語中的「行」（háng）和「列」（liè）所描述的單元格排列方向，可能是不同的。例如，中國大陸的「行」通常指一組水平排列的單元格，「列」指一組垂直排列的單元格；而臺灣、香港地區的「行」通常指一組垂直排列的單元格，「列」（或「欄」）指一組水平排列的單元格。</p>
+                  <p its-locale-filter-list="zh-hans" lang="zh-hans">在不同的地区，中文术语中的<ruby>“行”<rp>（</rp><rt>háng</rt><rp>）</rp></ruby>和<ruby>“列”<rp>（</rp><rt>liè</rt><rp>）</ruby>所描述的单元格排列方向，可能是不同的。例如，中国大陆的“行”通常指一组水平排列的单元格，“列”指一组垂直排列的单元格；而台湾、香港地区的“行”通常指一组垂直排列的单元格，“列”（或“栏”）指一组水平排列的单元格。</p>
+                  <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">在不同的地區，中文術語中的<ruby>「行」<rp>（</rp><rt>háng</rt><rp>）</rp></ruby>和<ruby>「列」<rp>（</rp><rt>liè</rt><rp>）</ruby>所描述的單元格排列方向，可能是不同的。例如，中國大陸的「行」通常指一組水平排列的單元格，「列」指一組垂直排列的單元格；而臺灣、香港地區的「行」通常指一組垂直排列的單元格，「列」（或「欄」）指一組水平排列的單元格。</p>
 
                   <p its-locale-filter-list="en" lang="en" class="checkme">
                     This document uses row/column in logical directions consistently, i.e., "row" is vertical in vertical writing mode and horizontal in horizontal writing mode, and "column" is horizontal in vertical writing mode and vertical in horizontal writing mode.
                   </p>
-                  <p its-locale-filter-list="zh-hans" lang="zh-hans">本文档采用「逻辑行」「逻辑列」来统一表述，也即，「行」在直排模式下垂直、在横排模式下水平，「列」在直排模式下水平、在横排模式下垂直。</p>
+                  <p its-locale-filter-list="zh-hans" lang="zh-hans">本文档采用“逻辑行”“逻辑列”来统一表述，也即，“行”在直排模式下垂直、在横排模式下水平，“列”在直排模式下水平、在横排模式下垂直。</p>
                   <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本文檔采用「邏輯行」「邏輯列」來統一表述，也即，「行」在直排模式下垂直、在橫排模式下水平，「列」在直排模式下水平、在橫排模式下垂直。</p>
                </div>
             </ol>
@@ -1536,7 +1536,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hant" lang="zh-hant">根據中國大陸的《标点符号用法》（GB/T 15834—2011），連接號的形式有短橫線[–]、一字線[—]和浪紋線[～]三種。</p>
             <div class="note" id="n026">
               <p its-locale-filter-list="en" lang="en">The <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) does not state the corresponding Unicode code point for the three types of connector marks. However, we can make the deduction that the long connector mark [—] is <span class="uname" translate="no">U+2014 EM DASH</span> [—] and the tilde [~] is <span class="uname" translate="no">U+FF5E FULLWIDTH TILDE</span> [～]. Since the short connector mark should take half the width of the long connector mark, it should be <span class="uname" translate="no">U+2013 EN DASH</span> [–]. The actual length of these connector marks may depend on the writing system as well as the typeface.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">《标点符号用法》（GB/T 15834—2011）中没有指定这三个符号的码位，但是基本上可以推断一字线是<span class="uname" translate="no">U+2014 EM DASH</span> [—]，浪纹线是<span class="uname" translate="no">U+FF5E FULLWIDTH TILDE</span> [～]。但是对于「短横线」，该标准5.1.6节规定「短横线比汉字『一』略短，占半个字位置」，因此可以是 <span class="uname" translate="no">U+2013 EN DASH</span> [–]。这些连接号的实际长短根据所用处理系统和使用字体会有区别。</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">《标点符号用法》（GB/T 15834—2011）中没有指定这三个符号的码位，但是基本上可以推断一字线是<span class="uname" translate="no">U+2014 EM DASH</span> [—]，浪纹线是<span class="uname" translate="no">U+FF5E FULLWIDTH TILDE</span> [～]。但是对于“短横线”，该标准5.1.6节规定“短横线比汉字『一』略短，占半个字位置”，因此可以是 <span class="uname" translate="no">U+2013 EN DASH</span> [–]。这些连接号的实际长短根据所用处理系统和使用字体会有区别。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">《標點符號用法》（GB/T 15834—2011）中沒有指定這三個符號的碼位，但是基本上可以推斷一字線是<span class="uname" translate="no">U+2014 EM DASH</span> [—]，浪紋線是<span class="uname" translate="no">U+FF5E FULLWIDTH TILDE</span> [～]。但是對於「短橫線」，該標準5.1.6節規定「橫短線比漢字『一』略短，佔半個字位置」，因此可以是<span class="uname" translate="no">U+2013 EN DASH</span> [–]。這些連接號的實際長短根據所用處理系統和使用字體會有區別。</p>
             </div>
           </li>
@@ -1549,7 +1549,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号为<span class="uname" translate="no">U+00B7 MIDDLE DOT</span> [·]。用于标示某些相关联成分之间的分界，如双书名号（书名号乙式）中分隔篇、章、卷，分隔外国人名中文译名、少数民族音译名，分隔日期的月和日等。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">間隔號為<span class="uname" translate="no">U+00B7 MIDDLE DOT</span> [·]。用於標示某些相關聯成分之間的分界，如書名號乙式（雙書名號）中分隔篇、章、卷，分隔外國人名中文譯名、少數民族音譯名，分隔日期的月和日等。</p>
             <p its-locale-filter-list="en" lang="en">Interpuncts apply to Chinese only. When a translated foreign name contains a Latin character, a western period should be used rather than a interpunct. For example, <span lang="zh-hant">比尔·盖茨</span> but <span lang="zh-hant">B. 盖茨</span>.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号为中文标点，当外语姓名包含西文首字母缩写作为单节时，原则上西文字母后面应该使用西文句点，如「比尔·盖茨」、「B. 盖茨」。</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号为中文标点，当外语姓名包含西文首字母缩写作为单节时，原则上西文字母后面应该使用西文句点，如“比尔·盖茨”、“B. 盖茨”。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">間隔號為中文標點，當外語姓名包含西文首字母縮寫作為單節時，原則上西文字母後面應該使用西文句點，如「比爾·蓋茨」、「B. 蓋茨」。</p>
             <p its-locale-filter-list="en" lang="en">The width of interpuncts varies in different regions. In principle, in Hong Kong and Taiwan, interpuncts should have the same dimensions as a Hanzi in both vertical writing mode and horizontal writing mode. In Mainland China, interpuncts take up half the space of a Hanzi. </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号在各个地区排版时宽度有所不同，原则上港台地区无论直排或横排，都占用一个汉字的大小，在中国大陆则占用半个汉字的大小。</p>
@@ -1677,7 +1677,7 @@ var respecConfig = {
         </h5>
 
         <p its-locale-filter-list="en" lang="en">Science and technology literature prefer <span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．] to <span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP</span> [。] so as to make a clear distinction from the letter [o] or digit [0]. </p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">科技文献中的句号多使用<span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．]替代<span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP</span> [。]，以避免同拉丁字母“o”或数字“0”混淆。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">科技文献中的“句号”多使用<span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．]替代<span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP</span> [。]，以避免同拉丁字母“o”或数字“0”混淆。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">科技文獻中的「句號」多使用<span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．]替代<span class="uname" translate="no">U+3002 IDEOGRAPHIC FULL STOP</span> [。]，以避免同拉丁字母「o」或數字「0」混淆。</p>
       </section>
 
@@ -1834,13 +1834,13 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
         在處理禁則之前，應優先按照排版風格處理[[[#punctuation_width_adjustment]]]，因為標點擠壓處理會影響換行位置。
       </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="translateme">排版时如果进行禁则处理，应遵守「先挤进，后推出」原则，即不希望标点符号出现在行首时，应在已经标点挤压的基础上再次检讨是否有机会将其挤到前一行，最后没有挤压机会再从前一行取最后一个字至下一行。前行多出来的空间需按照优先顺序拉伸，最后没有拉伸机会再按平均拉大字距的方式处理。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="translateme">排版时如果进行禁则处理，应遵守“先挤进，后推出”原则，即不希望标点符号出现在行首时，应在已经标点挤压的基础上再次检讨是否有机会将其挤到前一行，最后没有挤压机会再从前一行取最后一个字至下一行。前行多出来的空间需按照优先顺序拉伸，最后没有拉伸机会再按平均拉大字距的方式处理。</p>
       <div class="note" id="n033">
         <p its-locale-filter-list="en" lang="en">
           In principle, line-breaking rules within a single document should be consistent. However, in the case where three punctuation marks appear together, such as [。』」], prohibition against line break can be <a href="#prohibition-rules-none">ignored</a> to keep a reasonable spacing between characters in each line. This should be considered as a remedial measure and is not recommended generally.
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
-          原则上，一份文档内的级别应该统一。但若遇连续三个标点符号，如[。』」]等个别特殊状况局部采用「不处理」以避免字距过松造成体例不良，应该视为救济措施的个例，不作为推荐。
+          原则上，一份文档内的级别应该统一。但若遇连续三个标点符号，如[。』」]等个别特殊状况局部采用“不处理”以避免字距过松造成体例不良，应该视为救济措施的个例，不作为推荐。
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
           原則上，一份文檔內的級別應該統一。但若遇連續三個標點符號，如[。』」]等個別特殊狀況局部採用「不處理」以避免字距過松造成體例不良，應該視為救濟措施的個例，不作為推薦。
@@ -1941,7 +1941,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的調整空間</span>
         </h5>
         <p its-locale-filter-list="en" lang="en">Punctuation marks are divided into two types: "unadjustable" and "adjustable", and "adjustable" is divided into six categories according to the position of the adjustable space: left of character face in horizontal writing mode, right of character face in horizontal writing mode, left and right of character face in horizontal writing modes; top of character face in vertical writing mode, bottom of character face in vertical writing mode, top and bottom of character face in vertical writing mode.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">标点符号分为「不可调整」和「可调整」两类，「可调整」再根据调整空间分为六类：横排字面左、横排字面右、横排左右两侧；直排字面上、直排字面下、直排上下两侧。
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">标点符号分为“不可调整”和“可调整”两类，“可调整”再根据调整空间分为六类：横排字面左、横排字面右、横排左右两侧；直排字面上、直排字面下、直排上下两侧。
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號分為「不可調整」和「可調整」兩類，「可調整」再根據調整空間分為六類：橫排字面左、橫排字面右、橫排左右兩側；直排字面上、直排字面下、直排上下兩側。</p>
 
@@ -2091,7 +2091,7 @@ var respecConfig = {
       <ol>
         <li id="id105">
           <p its-locale-filter-list="en" lang="en">One Western letter used as a symbol for something, such as 'A' or 'B'.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用西文字母作为记号使用，如 A、B。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用西文字母作为记号使用，如“A”“B”。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">使用西文字母作為記號使用，如「A」「B」。</p>
         </li>
         <li id="id106">
@@ -2405,7 +2405,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">注音符号等宽且每个汉字标音的注音符号字数不超过三个，较为可控；而拉丁字母非等宽，拼式长短不一，且相邻拼式相连时应当有词间空格隔开。两类标音行间注的排版差异较大。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">注音符號等寬且每个漢字標音的注音符號字數不超過三個，較為可控；而拉丁字母非等寬，拼式長短不一，且相鄰拼式相連時應當有詞間空格隔開。兩類標音行間注的排版差異較大。</p>
       <p its-locale-filter-list="en" lang="en">Annotating with both Romanization and Zhuyin is a practical way to indicate the reading to readers who know only one of these systems, as well as helping study of or enquiries about the other one. Normally, when Romanization and Zhuyin are both provided, the Zhuyin are placed on the right side of the Han character while Romanization is set at the bottom of the Han character in horizontal writing mode and to the left side in vertical writing mode.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">拼注音共同标注是一种可行的作法，能同时为仅熟悉单一标音系统的两种读者提供汉字标音，并作为学习、査询另一种系统拼写的有效方式。一般情况下，「拼注音共同标注」的注音符号位于汉字右侧，横排时罗马拼音位于汉字下方，直排时位于汉字左侧。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">拼注音共同标注是一种可行的作法，能同时为仅熟悉单一标音系统的两种读者提供汉字标音，并作为学习、査询另一种系统拼写的有效方式。一般情况下，“拼注音共同标注”的注音符号位于汉字右侧，横排时罗马拼音位于汉字下方，直排时位于汉字左侧。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">拼注音共同標注是一種可行的作法，能同時為僅熟悉單一標音系統的二種讀者提供漢字標音，並作為學習、査詢另一種系統拼寫的有效方式。一般情況下，「拼注音共同標注」的注音符號位漢字右側，橫排時羅馬拼音位漢字下方，直排時位漢字左側。</p>
       <figure id="phonetic-in-both"> <img width="300" alt="拼注音共同標注排版示例" src="images/zh/phonetic-in-both.png">
         <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for both Romanization and Zhuyin</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">拼注音共同标注排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">拼注音共同標注排版示例。</span></figcaption>
@@ -2776,7 +2776,7 @@ var respecConfig = {
         <ol>
           <li id="id152">
             <p its-locale-filter-list="en" lang="en"> When the length of an annotation is shorter than that of its base text, the annotation can be center-aligned (in the case of Western script) or use larger tracking (in the case of Han characters). There are two methods to satisfy the latter, one is to equally distribute the spacing while the other is to align justified.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">当注文总长小于其基文的长度时，将注文设置居中（适用西文）或加大注文字距（适用汉字），后者更有间隔平均分配及始末端对齐两种方式。</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">当注文总长小于其基文的长度时，将注文设置居中（适用西文）或加大注文字距（适用汉字），后者更有“间隔平均分配”及“始末端对齐”两种方式。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">當注文總長小於其基文的長度時，將注文設置居中（適用西文）或加大注文字距（適用漢字），後者更有「間隔平均分配」及「始末端對齊」二種方式。</p>
           </li>
           <li id="id153">
@@ -2896,7 +2896,7 @@ var respecConfig = {
       </h4>
 
       <p its-locale-filter-list="en" lang="en">Line alignment method is a process for setting the alignment of each line of text so that the actual position of the text can be matched with their preset position. "Single line alignment" is a process for setting alignment for a run of text that is shorter than a given line length. This method is frequently used for items, headings, and poems. The following methods are available. </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">对齐系指使段落间各行文字实际配置位置能够与默认的文字配置位置符合。此处的「单行对齐」是指针对行长比预定行长更短的单行文字进行对齐的处理。这种方法常用于并排项目、标题和诗词等等。有着以下作法：</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">对齐系指使段落间各行文字实际配置位置能够与默认的文字配置位置符合。此处的“单行对齐”是指针对行长比预定行长更短的单行文字进行对齐的处理。这种方法常用于并排项目、标题和诗词等等。有着以下作法：</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">對齊係指使段落間各行文字實際配置位置能夠與預設的文字配置位置符合。此處的「單行對齊」是指針對行長比預定行長更短的單行文字進行對齊的處理。這種方法常用於並排項目、標題和詩詞等等。有著以下作法：</p>
       <ol>
         <li id="id158">
@@ -3077,7 +3077,7 @@ var respecConfig = {
         There are numerous reasons, e.g. [[[#prohibition_rules_for_line_start_end]]], that result in line lengths being uneven. Under such circumstances, <a href="#term.line-adjustment" class="termref">line adjustment</a> is required. With the exception of [[[#prohibition_rules_for_unbreakable_marks]]], a run of text may be broken at the specified line length, allowing the text to be arranged into even rows. Other than the last line of a paragraph, the start and end of a line must be placed at the specified line start and line end position respectively. The last line of the paragraph will be adjusted accordingly to the overall flow of the text with adjustments made to the width of its punctuation. It is not necessary for the end of the last line to be aligned with the rest of the text. Please refer to [[[#adjustments_of_orphans_and_widows]]]. If the text only comprises of 1 line, please refer to [[[#ways_of_alignments]]].
       </p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        由于[[[#prohibition_rules_for_line_start_end]]]等原因造成行的长度长短不一，这时需要进行「<a href="#term.line-adjustment" class="termref">行内调整</a>」。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先将整段文字按照指定的行长断开，排列成行。对于除了段落最后一行以外的各行，其行首、行尾必须分别放到指定行长的位置。对于段落最后一行，原则上按照排版风格进行标点宽度调整即可，末尾没有必要与指定行长的行尾对齐；最后一行需要调整的特殊情况，请参照[[[#adjustments_of_orphans_and_widows]]]。而当段落有且仅有一行时，请参照[[[#ways_of_alignments]]]。
+        由于[[[#prohibition_rules_for_line_start_end]]]等原因造成行的长度长短不一，这时需要进行“<a href="#term.line-adjustment" class="termref">行内调整</a>”。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先将整段文字按照指定的行长断开，排列成行。对于除了段落最后一行以外的各行，其行首、行尾必须分别放到指定行长的位置。对于段落最后一行，原则上按照排版风格进行标点宽度调整即可，末尾没有必要与指定行长的行尾对齐；最后一行需要调整的特殊情况，请参照[[[#adjustments_of_orphans_and_widows]]]。而当段落有且仅有一行时，请参照[[[#ways_of_alignments]]]。
       </p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
         由於[[[#prohibition_rules_for_line_start_end]]]等原因造成行的長度長短不一，這時需要進行「<a href="#term.line-adjustment" class="termref">行內調整</a>」。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先將整段文字按照指定的行長斷開，排列成行。對於除了段落最後一行以外的各行，其行首、行尾必須分別放到指定行長的位置。對於段落最後一行，原則上按照排版風格進行標點寬度調整即可，末尾沒有必要與指定行長的行尾對齊；最後一行需要調整的特殊情況，請參照[[[#adjustments_of_orphans_and_widows]]]。而當段落有且僅有一行時，請參照[[[#ways_of_alignments]]]。
@@ -3121,7 +3121,7 @@ var respecConfig = {
             Lines containing characters of different font sizes;
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            行内混用不同字号，比如该行有「行内夹注」并使用了小一些的字号；
+            行内混用不同字号，比如该行有“行内夹注”并使用了小一些的字号；
           </p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
             行內混用不同字號，比如該行有「行內夾註」並使用了小一些的字號；
@@ -3176,7 +3176,7 @@ var respecConfig = {
             Inter-character spacing like those between Western words, mixed texts, or as described in [[[#h-punctuation_adjustment_space]]], should be reduced in accordance to the prevailing typesetting style.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            <span class="leadin">挤压处理：</span>「挤压处理」是指按照预先规定的排版风格，压缩西文词距、中西间距和[[[#h-punctuation_adjustment_space]]]等处的做法。
+            <span class="leadin">挤压处理：</span>“挤压处理”是指按照预先规定的排版风格，压缩西文词距、中西间距和[[[#h-punctuation_adjustment_space]]]等处的做法。
           </p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
             <span class="leadin">擠壓處理：</span>「擠壓處理」是指按照預先規定的排版風格，壓縮西文詞距、中西間距和[[[#h-punctuation_adjustment_space]]]等處的做法。
@@ -3189,7 +3189,7 @@ var respecConfig = {
             Inter-character spacing like those between Western words, mixed texts or scenarios that are not limited by prohibition rules should be added in accordance to the prevailing typesetting style.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            <span class="leadin">拉伸处理：</span>「拉伸处理」是指按照预先规定的排版风格，拉伸西文词距、中西间距以及其他未被特殊规定禁止调整等处的做法。
+            <span class="leadin">拉伸处理：</span>“拉伸处理”是指按照预先规定的排版风格，拉伸西文词距、中西间距以及其他未被特殊规定禁止调整等处的做法。
           </p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
             <span class="leadin">拉伸處理：</span>「拉伸處理」是指按照預先規定的排版風格，拉伸西文詞距、中西間距以及其他未被特殊規定禁止調整等處的做法。
@@ -3201,7 +3201,7 @@ var respecConfig = {
         In order to make the composition tighter and more readable, the guiding principle is to attempt to implement space reduction first. In the event that is insufficient, then space can be added where acceptable to achieve justification.
       </p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        出于紧凑易读、节约版面的思路，行内调整要遵循「先挤压、后拉伸」的原则，即应该先挤压处理，仍旧无法满足需求之后再进行拉伸处理。
+        出于紧凑易读、节约版面的思路，行内调整要遵循“先挤压、后拉伸”的原则，即应该先挤压处理，仍旧无法满足需求之后再进行拉伸处理。
       </p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
         出於緊湊易讀、節約版面的思路，行內調整要遵循「先擠壓、後拉伸」的原則，即應該先擠壓處理，仍舊無法滿足需求之後再進行拉伸處理。
@@ -3212,7 +3212,7 @@ var respecConfig = {
           The word spacing in Western texts described here only pertains to situations which involve compositions of mixed Western and Han characters. The expected behaviour is different from that for purely Western texts, which will take into account the typeface, font size and letter spacing when doing text justification. In general, Western texts will add to word spacing and rarely uses space reduction.
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
-          本文涉及到行内的「西文词距」调整，仅是针对「在中文排版内混排的西文」，因此，与纯西文排版的习惯不尽相同。一般的西文排版中的词距，需要依照所用字体、字号、字距进行不同判断，而且一般只拉伸、不挤压。
+          本文涉及到行内的“西文词距”调整，仅是针对“在中文排版内混排的西文”，因此，与纯西文排版的习惯不尽相同。一般的西文排版中的词距，需要依照所用字体、字号、字距进行不同判断，而且一般只拉伸、不挤压。
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
           本文涉及到行內的「西文詞距」調整，僅是針對「在中文排版內混排的西文」，因此，與純西文排版的習慣不盡相同。一般的西文排版中的詞距，需要依照所用字體、字號、字距進行不同判斷，而且一般只拉伸、不擠壓。
@@ -3254,7 +3254,7 @@ var respecConfig = {
               In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up half a character width for a more pleasing aesthetic.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
-              行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定「5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。」
+              行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定“5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。”
             </p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
               行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全形字符則應占半形字符的寬度（即半個字位置），以使視覺效果更美觀。」
@@ -3524,7 +3524,7 @@ var respecConfig = {
       </div>
       <div class="note" id="n054">
         <p its-locale-filter-list="en" lang="en">In a multi-column format, block headings sometimes span multiple columns. These are called cross-column headings.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">多栏排列时，有着将换行标题置于复数栏的配置方法。称为跨栏标题。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">多栏排列时，有着将换行标题置于复数栏的配置方法。称为“跨栏标题”。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">多欄排列時，有著將換行標題置於複數欄的配置方法。稱為「跨欄標題」。</p>
       </div>
       <p its-locale-filter-list="en" lang="en">A run-in heading is a heading immediately followed by main text without a line break, and is usually used as a low level heading. Note that a low level heading can also appear as a block heading.</p>
@@ -4866,7 +4866,7 @@ var respecConfig = {
             as with earlier American point sizes, is considered to be 1⁄12 of a pica.
              <a href="https://en.wikipedia.org/wiki/Point_(typography)">[Definition from Wikipedia]</a>
           </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">字号的一种计量单位，常用的英美点制下1点约为0.35146mm，也被音译作「磅（因）」。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">字号的一种计量单位，常用的英美点制下1点约为0.35146mm，也被音译作“磅（因）”。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">字號的一種計量單位，常用的英美點制下1點約為0.35146mm，也被音譯作「磅（因）」。</p>
         </td>
       </tr>
@@ -5496,7 +5496,7 @@ var respecConfig = {
         <td>Zhuyin (Bopomofo)</td>
         <td>
           <p its-locale-filter-list="en" lang="en">The general name of Mandarin Phonetic Symbols and Taiwanese Phonetic Symbols.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">「国语注音符号」及「台湾方音符号」的统称。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">“国语注音符号”及“台湾方音符号”的统称。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">「國語注音符號」及「台灣方音符號」的統稱。</p>
         </td>
       </tr>


### PR DESCRIPTION
1. 简体中文中`「」`和`“”`混用，统一改为`“”`
2. 繁体中文中个别的`“”`改为`「」`
3. 将`「行」（háng）`改为
	```html
	<ruby>「行」<rp>（</rp><rt>háng</rt><rp>）</rp></ruby>
	```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kecrily/clreq/pull/449.html" title="Last updated on Mar 16, 2022, 7:50 AM UTC (9de2fea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/449/06e2034...kecrily:9de2fea.html" title="Last updated on Mar 16, 2022, 7:50 AM UTC (9de2fea)">Diff</a>