### PR TITLE
Remove extra colons when linking image

### DIFF
--- a/local.css
+++ b/local.css
@@ -65,6 +65,10 @@ figcaption {
   content: ':\00A0  ';
 }
 
+a .figno:after {
+  content: '';
+}
+
 a.termref:link,
 a.termref:hover,
 a.termref:visited,


### PR DESCRIPTION
Now they all render as expected

![image](https://user-images.githubusercontent.com/45708948/158939718-daa6fb26-5227-46d8-ae1b-7e9c4d80fd72.png)

close #451