### PR TITLE
No italics in Chinese in the figure caption

### DIFF
--- a/local.css
+++ b/local.css
@@ -61,6 +61,10 @@ figcaption {
   font-size: 90%;
 }
 
+.fig-title [its-locale-filter-list^="zh"] {
+    font-style: normal;
+}
+
 .figno:after {
   content: ':\00A0  ';
 }


### PR DESCRIPTION
It is not customary to use italics in Chinese.

Before:

![image](https://user-images.githubusercontent.com/45708948/165274586-27b27c3e-d492-4c2d-961f-19b3869f89c9.png)

After:

![image](https://user-images.githubusercontent.com/45708948/165274461-f11be8ef-c1cb-4203-bcd2-dc93ff55ef54.png)
