### PR TITLE
Unify the space between numeric value & unit

### DIFF
--- a/index.html
+++ b/index.html
@@ -874,51 +874,51 @@ var respecConfig = {
             <tbody>
               <tr>
                 <td>Size 0</td>
-                <td>42 pt</td>
+                <td>42&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 1</td>
-                <td>27.5/28 pt</td>
+                <td>27.5/28&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size Small 1</td>
-                <td>24 pt</td>
+                <td>24&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 2</td>
-                <td>21/22 pt</td>
+                <td>21/22&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size Small 2</td>
-                <td>18 pt</td>
+                <td>18&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 3</td>
-                <td>15.75/16 pt</td>
+                <td>15.75/16&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 4</td>
-                <td>13.75/14 pt</td>
+                <td>13.75/14&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size Small 4</td>
-                <td>12 pt</td>
+                <td>12&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 5</td>
-                <td>10.5 pt</td>
+                <td>10.5&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size Small 5</td>
-                <td>9 pt</td>
+                <td>9&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 6</td>
-                <td>7.875/8 pt</td>
+                <td>7.875/8&nbsp;pt</td>
               </tr>
               <tr>
                 <td>Size 7</td>
-                <td>5.25 pt</td>
+                <td>5.25&nbsp;pt</td>
               </tr>
             </tbody>
           </table>
@@ -933,51 +933,51 @@ var respecConfig = {
             <tbody>
               <tr>
                 <td>初号</td>
-                <td>42 pt</td>
+                <td>42&nbsp;pt</td>
               </tr>
               <tr>
                 <td>一号</td>
-                <td>27.5/28 pt</td>
+                <td>27.5/28&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）一号</td>
-                <td>24 pt</td>
+                <td>24&nbsp;pt</td>
               </tr>
               <tr>
                 <td>二号</td>
-                <td>21/22 pt</td>
+                <td>21/22&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）二号</td>
-                <td>18 pt</td>
+                <td>18&nbsp;pt</td>
               </tr>
               <tr>
                 <td>三号</td>
-                <td>15.75/16 pt</td>
+                <td>15.75/16&nbsp;pt</td>
               </tr>
               <tr>
                 <td>四号</td>
-                <td>13.75/14 pt</td>
+                <td>13.75/14&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）四号</td>
-                <td>12 pt</td>
+                <td>12&nbsp;pt</td>
               </tr>
               <tr>
                 <td>五号</td>
-                <td>10.5 pt</td>
+                <td>10.5&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）五号</td>
-                <td>9 pt</td>
+                <td>9&nbsp;pt</td>
               </tr>
               <tr>
                 <td>六号</td>
-                <td>7.875/8 pt</td>
+                <td>7.875/8&nbsp;pt</td>
               </tr>
               <tr>
                 <td>七号</td>
-                <td>5.25pt</td>
+                <td>5.25&nbsp;pt</td>
               </tr>
             </tbody>
           </table>
@@ -992,58 +992,58 @@ var respecConfig = {
             <tbody>
               <tr>
                 <td>初號</td>
-                <td>42 pt</td>
+                <td>42&nbsp;pt</td>
               </tr>
               <tr>
                 <td>一號</td>
-                <td>27.5/28 pt</td>
+                <td>27.5/28&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）一號</td>
-                <td>24 pt</td>
+                <td>24&nbsp;pt</td>
               </tr>
               <tr>
                 <td>二號</td>
-                <td>21/22 pt</td>
+                <td>21/22&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）二號</td>
-                <td>18 pt</td>
+                <td>18&nbsp;pt</td>
               </tr>
               <tr>
                 <td>三號</td>
-                <td>15.75/16 pt</td>
+                <td>15.75/16&nbsp;pt</td>
               </tr>
               <tr>
                 <td>四號</td>
-                <td>13.75/14 pt</td>
+                <td>13.75/14&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）四號</td>
-                <td>12 pt</td>
+                <td>12&nbsp;pt</td>
               </tr>
               <tr>
                 <td>五號</td>
-                <td>10.5 pt</td>
+                <td>10.5&nbsp;pt</td>
               </tr>
               <tr>
                 <td>小（新）五號</td>
-                <td>9 pt</td>
+                <td>9&nbsp;pt</td>
               </tr>
               <tr>
                 <td>六號</td>
-                <td>7.875/8 pt</td>
+                <td>7.875/8&nbsp;pt</td>
               </tr>
               <tr>
                 <td>七號</td>
-                <td>5.25pt</td>
+                <td>5.25&nbsp;pt</td>
               </tr>
             </tbody>
           </table>
 
-          <p its-locale-filter-list="en" lang="en">Size 5 is usually used for body text. Newspapers and magazines use both Size 5 and New Size 5. The acceptable minimum size for the text in content is Size 6  (7.875pt≒2.8mm). If a smaller size is used, it will be difficult to read due to the complex structure of Chinese characters.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">一般内文主要使用五号字（10.5pt≒3.7mm），而报纸、杂志则使用新五号字（9pt≒3.2mm），两种皆常用。而一般内文字最小使用到六号字（7.875pt≒2.8mm），若小于此尺寸，由于汉字结构复杂，较难阅读。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">一般內文主要使用五號字（10.5pt≒3.7mm），而報紙、雜誌則使用新五號字（9pt≒3.2mm），兩種皆常用。而一般內文字最小使用到六號字（7.875pt≒2.8mm），若小於此尺寸，由於漢字結構複雜，較難閱讀。</p>
+          <p its-locale-filter-list="en" lang="en">Size 5 is usually used for body text. Newspapers and magazines use both Size 5 and New Size 5. The acceptable minimum size for the text in content is Size 6  (7.875&nbsp;pt ≒ 2.8&nbsp;mm). If a smaller size is used, it will be difficult to read due to the complex structure of Chinese characters.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">一般内文主要使用五号字（10.5&nbsp;pt ≒ 3.7&nbsp;mm），而报纸、杂志则使用新五号字（9&nbsp;pt ≒ 3.2&nbsp;mm），两种皆常用。而一般内文字最小使用到六号字（7.875&nbsp;pt ≒ 2.8&nbsp;mm），若小于此尺寸，由于汉字结构复杂，较难阅读。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">一般內文主要使用五號字（10.5&nbsp;pt ≒ 3.7&nbsp;mm），而報紙、雜誌則使用新五號字（9&nbsp;pt ≒ 3.2&nbsp;mm），兩種皆常用。而一般內文字最小使用到六號字（7.875&nbsp;pt ≒ 2.8&nbsp;mm），若小於此尺寸，由於漢字結構複雜，較難閱讀。</p>
         </li>
         <li id="id52">
           <p its-locale-filter-list="en" lang="en">Line length should be multiples of the character size and the line ends should be aligned with each other.</p>
@@ -3550,8 +3550,8 @@ var respecConfig = {
       <ol>
         <li id="id181">
           <p its-locale-filter-list="en" lang="en"><span class="leadin">Character size for the heading:</span> The character size of headings should be selected in accordance with the level of headings. For example, when the character size of main text is 9 point, the small headings are usually set in 10 points, medium headings are usually set in 12 points and large headings are usually set in 14 points.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用不同的文字尺寸呈现标题的阶层，例如，有着大标、中标、小标时，小标比本文文字尺寸(例如:9pt)大一阶段(例如:10pt)，中标则比小标大一阶段(例如:12pt)，大标则比中标大一阶段(例如:14pt)。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">使用不同的文字尺寸呈現標題的階層，例如，有著大標、中標、小標時，小標比本文文字尺寸（例如：9pt）大一階段（例如：10pt），中標則比小標大一階段（例如：12pt），大標則比中標大一階段（例如：14pt）。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用不同的文字尺寸呈现标题的阶层，例如，有着大标、中标、小标时，小标比本文文字尺寸(例如：9&nbsp;pt)大一阶段(例如：10&nbsp;pt)，中标则比小标大一阶段(例如：12&nbsp;pt)，大标则比中标大一阶段(例如:14&nbsp;pt)。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">使用不同的文字尺寸呈現標題的階層，例如，有著大標、中標、小標時，小標比本文文字尺寸（例如：9&nbsp;pt）大一階段（例如：10&nbsp;pt），中標則比小標大一階段（例如：12&nbsp;pt），大標則比中標大一階段（例如：14&nbsp;pt）。</p>
           <div class="note" id="n055">
             <p its-locale-filter-list="en" lang="en">The character size of headings is usually larger than that of the main text. When this rule is applied, the characters in the heading should be 10% to 20% larger. And the character size of higher level headings is larger than the size of smaller size headings.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">也有采用将本文文字尺寸依照比例放大的方式，使用这方式时，以10%–20%上下，依阶层放大为佳。</p>
@@ -4878,12 +4878,12 @@ var respecConfig = {
         <td>
           <p its-locale-filter-list="en" lang="en">In typography, the point is the smallest unit of measure, used for measuring font size, leading, and other items on a printed page.
             The DTP point (desktop publishing point) as the de facto standard point is
-            defined as 1⁄72 of an international inch (about 0.35146mm) and,
+            defined as 1⁄72 of an international inch (about 0.35146&nbsp;mm) and,
             as with earlier American point sizes, is considered to be 1⁄12 of a pica.
              <a href="https://en.wikipedia.org/wiki/Point_(typography)">[Definition from Wikipedia]</a>
           </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">字号的一种计量单位，常用的英美点制下1点约为0.35146mm，也被音译作“磅（因）”。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">字號的一種計量單位，常用的英美點制下1點約為0.35146mm，也被音譯作「磅（因）」。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">字号的一种计量单位，常用的英美点制下1点约为0.35146&nbsp;mm，也被音译作“磅（因）”。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">字號的一種計量單位，常用的英美點制下1點約為0.35146&nbsp;mm，也被音譯作「磅（因）」。</p>
         </td>
       </tr>
       <tr id="term.pause-or-stop-punctuation-marks">


### PR DESCRIPTION
To resolve #452.

Main changes:

* Add one non-breaking space `&nbsp;` between numeric value and the `pt` (point) unit.
* Add one non-breaking space `&nbsp;` between numeric value and the `mm` (millimeter) unit.
* Replace some normal spaces between value and unit with non-breaking spaces.

Minor fixes:

- Replace some `:` (U+003A) with `：` (U+FF1A) for Simplified Chinese.
- Add spaces around some `≒` symbols.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/464.html" title="Last updated on May 19, 2022, 4:19 PM UTC (ac3fc9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/464/58376bc...realfish:ac3fc9e.html" title="Last updated on May 19, 2022, 4:19 PM UTC (ac3fc9e)">Diff</a>