### PR TITLE
Revise for “字宽”/“字寬”, “character width”, and “em”

### DIFF
--- a/index.html
+++ b/index.html
@@ -1239,7 +1239,7 @@ var respecConfig = {
                   <p its-locale-filter-list="en" lang="en">Set horizontally without changing orientation (like <a href="https://w3c.github.io/jlreq/#handling_of_tatechuyoko">tate-chu-yoko</a> in Japanese). This is usually applied to numbers comprising two to three digits.</p>
                   <p its-locale-filter-list="zh-hans" lang="zh-hans">保持正常方向，横排处理（如日文的<a href="https://w3c.github.io/jlreq/#handling_of_tatechuyoko">纵中横排</a>）。主要应用于二至三位数字。</p>
                   <p its-locale-filter-list="zh-hant" lang="zh-hant">保持正常方向，橫排處理（如日文的<a href="https://w3c.github.io/jlreq/#handling_of_tatechuyoko">縱中橫排</a>）。主要應用於二至三位數字。</p>
-                  <p its-locale-filter-list="en" lang="en" class="checkme">In principle, if numbers are arranged horizontally in a vertical writing mode, the width of the numbers should not exceed 1 em. This rule originated in the letterpress printing era due to the fixed width of each line. Therefore, in vertical writing mode, Western text or <a href="#term.european-numerals" class="termref">European numerals</a> are not limited to two digits, but the width should not exceed 1 em. Some commonly seen examples include "3.0", "A+" and "2B".</p>
+                  <p its-locale-filter-list="en" lang="en" class="checkme">In principle, if numbers are arranged horizontally in a vertical writing mode, the width of the numbers should not exceed 1&nbsp;em. This rule originated in the letterpress printing era due to the fixed width of each line. Therefore, in vertical writing mode, Western text or <a href="#term.european-numerals" class="termref">European numerals</a> are not limited to two digits, but the width should not exceed 1&nbsp;em. Some commonly seen examples include "3.0", "A+" and "2B".</p>
                   <p its-locale-filter-list="zh-hans" lang="zh-hans">数字在直排行内横排，原则上不超过一个汉字的字幅。这是从活字印刷时代起，每行宽度固定所致。故直排时，西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>横排不限于两位数，但原则上不能超过一个汉字。现代常见的用法还包括[3.0]、[A+]、[2B]等。</p>
                   <p its-locale-filter-list="zh-hant" lang="zh-hant">數字於直排行內橫排，原則上不超過一個漢字的字幅。這是從活字印刷時代起，每行寬度固定所致。故直排時，西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>橫排不限於二位數，但原則上不能超過一個漢字。現代常見的用法還包括[3.0]、[A+]、[2B]等。</p>
                 </li>
@@ -1496,7 +1496,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">破折号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">破折號</span></p>
 
-            <p its-locale-filter-list="en" lang="en" class="checkme">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or adding new content to the context, appearing as a horizontally and vertically centered line, and take 2 em. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] are also often used.</p>
+            <p its-locale-filter-list="en" lang="en" class="checkme">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or adding new content to the context, appearing as a horizontally and vertically centered line, and take 2&nbsp;em. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] are also often used.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">破折号表示语气或声音的延续、语意的转换或行文的补充。呈现上为一条在水平和垂直方向均位于字面正中的直线，占两个汉字空间。推荐使用占两个汉字宽度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用两个连续的<span class="uname" translate="no">U+2014 EM DASH</span> [—]来实现。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">破折號表示語氣或聲音的延續、語意的轉換或行文的補充。呈現上為一條在水平和垂直方向均位於字面正中的直線，占兩個漢字空間。推薦使用占兩個漢字寬度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用兩個連續的<span class="uname" translate="no">U+2014 EM DASH</span> [—]來實現。</p>
           </li>
@@ -1648,13 +1648,13 @@ var respecConfig = {
       <p its-locale-filter-list="en" lang="en">Connector marks should take up the same dimensions as a single character, and be vertically and horizontally centered within its square frame. Among the connector marks, the EN DASH should have a short length to distinguish it from the Chinese character [一], which means one. And they should be positioned in the same direction as the characters they mark.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">连接号位于字面正中，占一个汉字的大小，其中，甲式连接号在横排时，符号的直线长度应稍小于汉字“一”以避免歧义，按照文字书写方向使用相应的标注方向。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">連接號位字面正中，佔一個漢字的大小，其中，甲式連接號在橫排時，符號的直線長度應稍小於漢字「一」以避免歧義，依文字書寫方向使用相應的標注方向。</p>
-      <p its-locale-filter-list="en" lang="en" class="checkme">Middle dots should be vertically and horizontally centered within their square frame. To make more economical use of the available space, or to tighten the overall spacing, sometimes the solidus can have 1/2 em.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Middle dots should be vertically and horizontally centered within their square frame. To make more economical use of the available space, or to tighten the overall spacing, sometimes the solidus can have 1/2&nbsp;em.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号位于字面正中，占一个汉字的大小，直、横排方向一致。为了节省排版空间、使词组或数字较紧凑地排列，可以使用半个汉字大小的间隔号。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">間隔號位於字面正中，佔一個漢字的大小，直、橫排方向一致。為了節省排版空間、使詞組或數字較緊湊地排列，可以使用半個漢字大小的間隔號。</p>
       <p its-locale-filter-list="en" lang="en">Interlinear marks like proper noun marks, book title mark type A, and emphasis dots should be positioned underneath the marked characters in horizontal writing mode. In vertical writing mode, emphasis dots should be positioned to the right side of the marked characters so as not to affect the characters above and beneath them.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">标注在行间的标号需以不影响上下行文字为原则进行配置。包括：专名号、甲式书名号等两个符号，位于被标注文字底端（横排位于文字下方、直排位于文字左侧）；着重号横排时位于文字底端（下方）、直排时位于文字顶端（右侧）。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">標注於行間的標號需以不影響上下行文字為原則進行配置。包括：專名號、甲式書名號等二個符號，位受注文字底端（橫排位文字下方、直排位文字左側）；着重號橫排時位受注文字底端（下方）、直排時位在受注文字頂端（右側）。</p>
-      <p its-locale-filter-list="en" lang="en" class="checkme">Solidi should be vertically and horizontally centered within their square frame. As GB rules, it should take 1/2 em, whereas in Taiwan, there is no clear rule about its dimensions but most publications will give them the same dimensions as a single character.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Solidi should be vertically and horizontally centered within their square frame. As GB rules, it should take 1/2&nbsp;em, whereas in Taiwan, there is no clear rule about its dimensions but most publications will give them the same dimensions as a single character.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">分隔号位于字面正中，中国大陆的国标规定排版时占半个汉字的大小；而在台湾则未有相关的规定，但多数出版品使用一个汉字的大小。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">分隔號位於字面正中，中國大陸的國標規定排版時佔半個漢字的大小；而在台灣則未有相關的規定，但多數出版品使用一個漢字的大小。</p>
       <p its-locale-filter-list="en" lang="en">
@@ -1714,7 +1714,7 @@ var respecConfig = {
         <p its-locale-filter-list="en" lang="en">Exclamatory question marks are defined in the General Rules for Punctuation (GB/T 15834—2011) as an extended usage of exclamation marks. For questions with a strong exclamatory tone of voice, it is appropriate to add an exclamation mark after the question mark (?!). However, it is common to see a question mark added after an exclamation mark (!?) in numerous publications as well. In addition, <abbr class="exclude" title="Guobiao standards">GB</abbr> rules indicate that it is acceptable to chain up to 3 exclamation marks or question marks in succession (!!!, ???) for exclamatory statements or interrogative sentences which require greater emphasis.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">叹问号于中国大陆《标点符号用法》（GB/T 15834—2011）中作为叹号的延伸用法，当语气同时具备强烈的疑问与感叹时，可于问号后加上叹号（?!）。然而在许多作品中，也常见在叹号后加上问号（!?）的用法。此外，在同标准的问号与叹号用法也指明在语气加重时可叠用问号或者叹号，最多可叠用到三个（!!!、???）。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">嘆問號於中國大陸《標點符號用法》（GB/T 15834—2011）中作為嘆號的延伸用法，當語氣同時具備強烈的疑問與感嘆時，可於問號後加上嘆號（?!）。然而在許多作品中，也常見在嘆號後加上問號（!?）的用法。此外，在同標準的問號與嘆號用法也指明在語氣加重時可疊用問號或者嘆號，最多可疊用到三個（!!!、???）。</p>
-        <p its-locale-filter-list="en" lang="en" class="checkme">In print publications, <abbr class="exclude" title="Guobiao standards">GB</abbr> rules state that when question marks and exclamation marks are chained, they are considered 1 em. Double question marks or double exclamation marks also 1 em. Triple question marks or triple exclamation marks are 2 em. In addition, for vertical writing mode in Taiwan, chained question marks or exclamation marks are upright and take up 1 em.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">In print publications, <abbr class="exclude" title="Guobiao standards">GB</abbr> rules state that when question marks and exclamation marks are chained, they are considered 1&nbsp;em. Double question marks or double exclamation marks also 1&nbsp;em. Triple question marks or triple exclamation marks are 2&nbsp;em. In addition, for vertical writing mode in Taiwan, chained question marks or exclamation marks are upright and take up 1&nbsp;em.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">排版上，《标点符号用法》规定问号与叹号连用时，占一个字位置；两个问号或叹号叠用时，占一个字位置；三个问号或叹号叠用时，占两个字位置。此外，在台湾直排的习惯中，叹问号连用与问号、叹号叠用时，符号多直立，并且占一个字的位置。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">排版上，《標點符號用法》規定問號與嘆號連用時，佔一個字位置；兩個問號或嘆號疊用時，佔一個字位置；三個問號或嘆號疊用時，佔兩個字位置。此外，在台灣直排的習慣中，嘆問號連用與問號、嘆號疊用時，符號多直立，並且佔一個字的位置。</p>
         <div class="note">
@@ -1883,7 +1883,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2 em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2&nbsp;em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，在行间应为一体，视作一个字符存在，不能为了适配分行而拆成两行。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，在行間應為一體，視作一個字元存在，不得以適配分行之由拆至二行。</p>
         <ol>
@@ -1891,7 +1891,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Two-em dash.</span></p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">乙式括号与破折号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">乙式括號與破折號</span></p>
-            <p its-locale-filter-list="en" lang="en" class="checkme">Two-em dashes [<span lang="zh">——</span>] can be created using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [<span lang="zh">⸺</span>] or two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [<span lang="zh">—</span>] characters. Both alternatives should take 2 em.</p>
+            <p its-locale-filter-list="en" lang="en" class="checkme">Two-em dashes [<span lang="zh">——</span>] can be created using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [<span lang="zh">⸺</span>] or two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [<span lang="zh">—</span>] characters. Both alternatives should take 2&nbsp;em.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">乙式括号与破折号是占两个汉字空间的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] 或连续使用两个<span class="uname" translate="no">U+2014 EM DASH</span> [—]。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">乙式括號與破折號為佔二個漢字空間的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] 或連續使用兩個<span class="uname" translate="no">U+2014 EM DASH</span> [—]。</p>
           </li>
@@ -1939,7 +1939,7 @@ var respecConfig = {
       <!-- oldid -->
       <span id="compression_rules_for_consecutive_punctuation_marks"></span>
 
-      <p its-locale-filter-list="en" lang="en" class="checkme">Punctuation marks between characters (except for two-em dash and horizontal ellipsis) usually occupy 2 em, making it easy to recognize and lay out. Some layout styles do not adjust the punctuation width at all. However, in order to make the the composition tighter and more readable, and when implementing [[[#prohibition_rules_for_line_start_end]]], the width of the punctuation marks needs to be adjusted. Whether to adjust depends on the judgment of the typesetting style. Many publications in Taiwan do not adjust punctuation width, while most publications in Mainland China and Hong Kong do adjust punctuation width. Punctuation width adjustment is usually divided into two situations: 1) when consecutive punctuation marks appear 2) when the punctuation mark appears at the beginning or end of a line. There are more than one style of width adjustment, and only the basic principles are explained below.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Punctuation marks between characters (except for two-em dash and horizontal ellipsis) usually occupy 2&nbsp;em, making it easy to recognize and lay out. Some layout styles do not adjust the punctuation width at all. However, in order to make the the composition tighter and more readable, and when implementing [[[#prohibition_rules_for_line_start_end]]], the width of the punctuation marks needs to be adjusted. Whether to adjust depends on the judgment of the typesetting style. Many publications in Taiwan do not adjust punctuation width, while most publications in Mainland China and Hong Kong do adjust punctuation width. Punctuation width adjustment is usually divided into two situations: 1) when consecutive punctuation marks appear 2) when the punctuation mark appears at the beginning or end of a line. There are more than one style of width adjustment, and only the basic principles are explained below.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">标注在字间的标点符号（除乙式括号、破折号、省略号以外）通常占一个汉字宽度，使其易于识别、适合配置及排版，有些排版风格完全不对标点宽度进行任何调整。但是为了让文字体裁更加紧凑易读，以及执行[[[#prohibition_rules_for_line_start_end]]]时，就需要对标点符号的宽度进行调整。是否调整取决于对排版风格的判断，台湾的很多印刷品都采用不调整的风格；而在中国大陆和香港的出版物中，多数采取调整的风格。标点符号宽度调整通常分为两种情形：1. 标点符号连续出现 2.标点出现在行首或行尾。调整时的风格不尽相同，下文仅阐述基本原则。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">標註在字間的標點符號（除乙式括號、破折號、省略號以外）通常占一個漢字寬度，使其易於識別、適合配置及排版，有些排版風格完全不對標點寬度進行任何調整。但是為了讓文字體裁更加緊湊易讀，以及執行[[[#prohibition_rules_for_line_start_end]]]時，就需要對標點符號的寬度進行調整。是否調整取決於對排版風格的判斷，臺灣的很多印刷品都採用不調整的風格；而在中國大陸和香港的出版物中，多數採取調整的風格。標點符號寬度調整通常分為兩種情形：1. 標點符號連續出現 2.標點出現在行首或行尾。調整時的風格不盡相同，下文僅闡述基本原則。</p>
 
@@ -1965,7 +1965,7 @@ var respecConfig = {
           </figcaption>
         </figure>
 
-        <p its-locale-filter-list="en" lang="en" class="checkme">Unadjustable punctuations include: <abbr class="exclude" title="Guobiao standards">GB</abbr>-style short connector marks, interpuncts, and solidi, because these punctuation points always take 1/2 em; exclamation marks and question marks in horizontal writing mode in Hong Kong and Taiwan, and colons, semicolons, question marks, exclamation marks in vertical writing mode in Chinese Mainland, Hong Kong, and Taiwan, because these punctuations always take 1 em.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">Unadjustable punctuations include: <abbr class="exclude" title="Guobiao standards">GB</abbr>-style short connector marks, interpuncts, and solidi, because these punctuation points always take 1/2&nbsp;em; exclamation marks and question marks in horizontal writing mode in Hong Kong and Taiwan, and colons, semicolons, question marks, exclamation marks in vertical writing mode in Chinese Mainland, Hong Kong, and Taiwan, because these punctuations always take 1&nbsp;em.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
           不可调整的标点包括：中国大陆GB式的半字连接号、间隔号、分隔号，因为这几个标点固定半个字宽；横排的港台式问号、感叹号和直排的冒号、分号、问号、感叹号（包括GB偏靠式和港台居中式），因为这几个标点固定一个字宽。
         </p>
@@ -1995,7 +1995,7 @@ var respecConfig = {
         </p>
 
         <p its-locale-filter-list="en" lang="en" class="checkme">
-          The adjustment in principle should be: if any two adjacent punctuation marks take 2 em, they should be reduced to 1.5 em. Based on this principle, the typography style is allowed to be further adjusted so that the two punctuation marks take only 1 em.
+          The adjustment in principle should be: if any two adjacent punctuation marks take 2&nbsp;em, they should be reduced to 1.5&nbsp;em. Based on this principle, the typography style is allowed to be further adjusted so that the two punctuation marks take only 1&nbsp;em.
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
           原则上的调整度应为：如果任意两个相邻标点符号占用2个字宽，应当缩减成1.5个字宽。在此原则上，允许排版风格进一步调整让两个符号只占1个字宽。
@@ -2143,7 +2143,7 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en" class="checkme">In horizontal writing mode, the basic approach uses proportional fonts to represent Western text and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4 em, except at the line start or end.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">In horizontal writing mode, the basic approach uses proportional fonts to represent Western text and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4&nbsp;em, except at the line start or end.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
       <div class="note" id="n036">
@@ -2181,7 +2181,7 @@ var respecConfig = {
           </figure>
         </li>
         <li id="id111">
-          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western letters with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Latin letters compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western letter or European numeral, up to a width of 1/4 em, except at the line start or end.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western letters with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Latin letters compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western letter or European numeral, up to a width of 1/4&nbsp;em, except at the line start or end.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">采用比例字体，将文字顺时针旋转90°配置。当文中的西文为一般单词、语句或四位数以上的阿拉伯数字时，采用此方法配置。汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">採用比例字體，將文字順時針旋轉90度配置。當文中的西字為一般單字詞、語句，或阿拉伯數在四位數以上時，採用此方法配置。漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
           <figure id="latin-90-clockwise-2">
@@ -2231,7 +2231,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">西文單字詞在可使用連字符處之外，不得分隔為兩行。</p>
         </li>
         <li id="id115">
-          <p its-locale-filter-list="en" lang="en" class="checkme">Tracking or spacing between a Han character and a Western letter or numeral is up to 1/4 em.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">Tracking or spacing between a Han character and a Western letter or numeral is up to 1/4&nbsp;em.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母之间，原则上使用不多于四分之一个汉字宽的字距或空白。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母之間，原則上使用不多於四分之一個漢字寬的字距或空白。</p>
         </li>
@@ -2271,7 +2271,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
       <ol>
         <li id="id119">
-          <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between Han and Western letters, it is possible to use flexible spacing of up to 1/2 em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han character before and after the Western language span snaps to the grid lines.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between Han and Western letters, it is possible to use flexible spacing of up to 1/2&nbsp;em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han character before and after the Western language span snaps to the grid lines.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">汉字与西文字母间不使用四分之一汉字宽的字距，而是加入大于零、小于等于二分之一汉字宽的弹性空白，使西文所占的空间为汉字的整数倍，确保西文前后的汉字都能纵横对齐。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母間不使用四分之一漢字寬之字距，而是加入大於零、小於等於二分之一漢字寬的彈性空白，使西文所佔之空間為漢字的整數倍，確保西文前後之漢字都能縱橫對齊。</p>
         </li>
@@ -2624,7 +2624,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hant" lang="zh-hant">若注文長於基文且位於行端，二者可向行端對齊。</p>
           </li>
           <li id="id138">
-            <p its-locale-filter-list="en" lang="en">The space between two adjacent annotations should not be smaller than the size of a normal Western-language space, which is about 1/4 em. Due to the limitation of typesetting technologies, there is usually no space between the rather long phonetic annotations in many printed publications. Luckily, this is not likely to lead to ambiguity because each Han character contains one syllable and most Pinyin fragments are easy to tell apart. However, these annotations can be misleading sometimes. For example, character-based phonetic annotations may result in the false impression that they are word-based. Also, the accidentally concatenated annotations may disrupt word boundaries, which alters the semantic meanings of the words.</p>
+            <p its-locale-filter-list="en" lang="en">The space between two adjacent annotations should not be smaller than the size of a normal Western-language space, which is about 1/4&nbsp;em. Due to the limitation of typesetting technologies, there is usually no space between the rather long phonetic annotations in many printed publications. Luckily, this is not likely to lead to ambiguity because each Han character contains one syllable and most Pinyin fragments are easy to tell apart. However, these annotations can be misleading sometimes. For example, character-based phonetic annotations may result in the false impression that they are word-based. Also, the accidentally concatenated annotations may disrupt word boundaries, which alters the semantic meanings of the words.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">相邻注文的间距不应小于西文词间空格的宽度（约1/4字宽）。但受排版技术限制，许多出版物中过长的相邻注文都会紧密相连。因汉字为单音节文字且多数汉语拼音音节都容易辨认界限，并不容易出现标音的歧义，但由于每个汉字的标音都已隔开，意外的相连易造成分词连写的假象，且相连的标音时常横跨词界，打乱语义。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">相鄰注文的間距不應小於西文詞間空格的寬度（約1/4字寬）。但受排版技術限制，許多出版物中過長的相鄰注文都會緊密相連。因漢字為單音節文字且多數漢語拼音音節都容易辨認界限，並不容易出現標音的歧義，但由於每個漢字的標音都已隔開，意外的相連易造成分詞連寫的假象，且相連的標音時常橫跨詞界，打亂語義。</p>
           </li>
@@ -2711,7 +2711,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hant" lang="zh-hant">注文有時在下方。</p>
           </li>
           <li id="id150">
-            <p its-locale-filter-list="en" lang="en">Both the phonetic annotations and the base text are separated at word boundaries. The adjacent annotations are separated by an approximately 1/2 em wide space, while the tracking inside the base text is usually normal.</p>
+            <p its-locale-filter-list="en" lang="en">Both the phonetic annotations and the base text are separated at word boundaries. The adjacent annotations are separated by an approximately 1/2-em wide space, while the tracking inside the base text is usually normal.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">正文与标音双方皆分词连写。相邻基文之间有约1/2字宽的空格隔开，基文内部字距通常正常。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">正文與標音雙方皆分詞連寫。相鄰基文之間有約1/2字寬的空格隔開，基文內部字距通常正常。</p>
           </li>
@@ -3245,7 +3245,7 @@ var respecConfig = {
       <ol type="a">
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            At the end of a line: adjusted to fixed 1/2 em.
+            At the end of a line: adjusted to fixed 1/2&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行末的标点。调成固定的半个汉字宽。
@@ -3255,7 +3255,7 @@ var respecConfig = {
           </p>
           <aside class="note">
             <p its-locale-filter-list="en" lang="en">
-              In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up 1/2 em for a more pleasing aesthetic.
+              In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up 1/2&nbsp;em for a more pleasing aesthetic.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定“5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。”
@@ -3268,7 +3268,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Spacing between Western texts: for lines with numerous instances of Western text, their spacing should be processed at the same time, with equal treatment. The minimum space between each Western text should be 1/4 em.
+            Spacing between Western texts: for lines with numerous instances of Western text, their spacing should be processed at the same time, with equal treatment. The minimum space between each Western text should be 1/4&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最小可以挤压到四分之一汉字宽。
@@ -3280,7 +3280,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Interpuncts: space reduction must take place equally on both sides of the character. The minimum space is 0, whereby the interpunct ends up being 1/2 em.
+            Interpuncts: space reduction must take place equally on both sides of the character. The minimum space is 0, whereby the interpunct ends up being 1/2&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的间隔号。挤压时必须同时从字面两侧、同等量处理，最小挤到0，即变成半个汉字字宽。
@@ -3292,7 +3292,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Brackets: space reduction can take place before the opening bracket and after the closing bracket. If multiple brackets occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the bracket is 1/2 em.
+            Brackets: space reduction can take place before the opening bracket and after the closing bracket. If multiple brackets occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the bracket is 1/2&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的夹注符号。可以对开始夹注符号的前侧、结束夹注符号的后侧进行挤压，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
@@ -3304,7 +3304,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Commas, secondary commas and semi-colons: space reduction should follow [[[#h-punctuation_adjustment_space]]]. Spacing can be reduced at the end of the punctuation mark or equally on either side. If multiple of such punctuations occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the punctuation mark is 1/2 em.
+            Commas, secondary commas and semi-colons: space reduction should follow [[[#h-punctuation_adjustment_space]]]. Spacing can be reduced at the end of the punctuation mark or equally on either side. If multiple of such punctuations occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the punctuation mark is 1/2&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的逗号、顿号、分号。挤压空间依照[[[#h-punctuation_adjustment_space]]]，可以是后侧，也可以是字面两侧同时，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
@@ -3316,7 +3316,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Spacing between Han characters and Western texts: if there are numerous instances of mixed texts, space reduction should be processed at the same time, with equal treatment, with the minimum space being 1/8 em.
+            Spacing between Han characters and Western texts: if there are numerous instances of mixed texts, space reduction should be processed at the same time, with equal treatment, with the minimum space being 1/8&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             行内的中西间距，最小挤为八分之一汉字宽。一行内若有多处，应该同时、同等量处理。
@@ -3326,7 +3326,7 @@ var respecConfig = {
           </p>
           <aside class="note">
             <p its-locale-filter-list="en" lang="en" class="checkme">
-              Certain typesetting styles have a fixed default spacing between Han characters and Western texts, for example 1/4 em, in such cases, adjustment is not allowed.
+              Certain typesetting styles have a fixed default spacing between Han characters and Western texts, for example 1/4&nbsp;em, in such cases, adjustment is not allowed.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被挤压。
@@ -3339,7 +3339,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Periods, question marks and exclamation marks: in accordance to [[[#h-punctuation_adjustment_space]]], if there is available space, spacing can be reduced up until the minimum size of 1/2 em.
+            Periods, question marks and exclamation marks: in accordance to [[[#h-punctuation_adjustment_space]]], if there is available space, spacing can be reduced up until the minimum size of 1/2&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的句号、问号、感叹号。依照[[[#h-punctuation_adjustment_space]]]，如果有调整空间则可以挤压，最小挤为半个汉字字宽。
@@ -3349,7 +3349,7 @@ var respecConfig = {
           </p>
           <aside class="note">
             <p its-locale-filter-list="en" lang="en" class="checkme">
-              As these punctuation marks indicate a longer pause at the end of a sentence, certain typesetting styles do not allow line adjustment to be made on them, maintaining their width to be 1 em.
+              As these punctuation marks indicate a longer pause at the end of a sentence, certain typesetting styles do not allow line adjustment to be made on them, maintaining their width to be 1&nbsp;em.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               由于句末标点表示停顿较大，因此有些排版风格禁止此项调整，而保持句号、问号、感叹号固定一个字宽。
@@ -3382,7 +3382,7 @@ var respecConfig = {
       <ol type="a">
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Word spacing between Western texts: for lines with several Western word spaces, these should be processed at the same time, with equal treatment. Each word space can be expanded to a maximum of 1/2 em.
+            Word spacing between Western texts: for lines with several Western word spaces, these should be processed at the same time, with equal treatment. Each word space can be expanded to a maximum of 1/2&nbsp;em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最大可以拉伸到半个汉字字宽。
@@ -3394,7 +3394,7 @@ var respecConfig = {
 
         <li>
           <p its-locale-filter-list="en" lang="en" class="checkme">
-            Space between Han characters and Western texts can be expanded from the default width (e.g., 1/4 em). They should be processed at the same time, with equal treatment.
+            Space between Han characters and Western texts can be expanded from the default width (e.g., 1/4&nbsp;em). They should be processed at the same time, with equal treatment.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             行内的中西间距，从默认宽度（如四分之一汉字宽）开始拉伸，一行内若有多处，应该同时、同等量处理，最大可拉大到半个汉字字宽。
@@ -3404,7 +3404,7 @@ var respecConfig = {
           </p>
           <aside class="note">
             <p its-locale-filter-list="en" lang="en" class="checkme">
-              Numerous typesetting styles practically only allow expansion of space up to 1/3 em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example 1/4 em, in such cases, adjustments are not allowed.
+              Numerous typesetting styles practically only allow expansion of space up to 1/3&nbsp;em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example 1/4&nbsp;em, in such cases, adjustments are not allowed.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               很多排版风格在实际处理上，只允许最大拉伸到三分之一汉字宽。与上述挤压处理一样，在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被拉伸。
@@ -3817,7 +3817,7 @@ var respecConfig = {
           <td>203C</td>
           <td>DOUBLE EXCLAMATION MARK</td>
           <td>
-            <p its-locale-filter-list="en" lang="en" class="checkme">Takes 1 em.
+            <p its-locale-filter-list="en" lang="en" class="checkme">Takes 1&nbsp;em.
             <p its-locale-filter-list="zh-hans" lang="zh-hans">占一个汉字大小。
             <p its-locale-filter-list="zh-hant" lang="zh-hant">佔一個漢字大小。
           </td>
@@ -3839,7 +3839,7 @@ var respecConfig = {
           <td>2047</td>
           <td>DOUBLE QUESTION MARK</td>
           <td>
-            <p its-locale-filter-list="en" lang="en" class="checkme">Takes 1 em.
+            <p its-locale-filter-list="en" lang="en" class="checkme">Takes 1&nbsp;em.
             <p its-locale-filter-list="zh-hans" lang="zh-hans">占一个汉字大小。
             <p its-locale-filter-list="zh-hant" lang="zh-hant">佔一個漢字大小。
           </td>

--- a/index.html
+++ b/index.html
@@ -1496,7 +1496,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">破折号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">破折號</span></p>
 
-            <p its-locale-filter-list="en" lang="en">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or adding new content to the context, appearing as a horizontally and vertically centered line, and take two character widths. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] are also often used.</p>
+            <p its-locale-filter-list="en" lang="en" class="checkme">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or adding new content to the context, appearing as a horizontally and vertically centered line, and take 2 em. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] are also often used.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">破折号表示语气或声音的延续、语意的转换或行文的补充。呈现上为一条在水平和垂直方向均位于字面正中的直线，占两个汉字空间。推荐使用占两个汉字宽度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用两个连续的<span class="uname" translate="no">U+2014 EM DASH</span> [—]来实现。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">破折號表示語氣或聲音的延續、語意的轉換或行文的補充。呈現上為一條在水平和垂直方向均位於字面正中的直線，占兩個漢字空間。推薦使用占兩個漢字寬度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用兩個連續的<span class="uname" translate="no">U+2014 EM DASH</span> [—]來實現。</p>
           </li>
@@ -1939,7 +1939,7 @@ var respecConfig = {
       <!-- oldid -->
       <span id="compression_rules_for_consecutive_punctuation_marks"></span>
 
-      <p its-locale-filter-list="en" lang="en">Punctuation marks between characters (except for two-em dash and horizontal ellipsis) usually occupy two character widths, making it easy to recognize and lay out. Some layout styles do not adjust the punctuation width at all. However, in order to make the the composition tighter and more readable, and when implementing [[[#prohibition_rules_for_line_start_end]]], the width of the punctuation marks needs to be adjusted. Whether to adjust depends on the judgment of the typesetting style. Many publications in Taiwan do not adjust punctuation width, while most publications in Mainland China and Hong Kong do adjust punctuation width. Punctuation width adjustment is usually divided into two situations: 1) when consecutive punctuation marks appear 2) when the punctuation mark appears at the beginning or end of a line. There are more than one style of width adjustment, and only the basic principles are explained below.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Punctuation marks between characters (except for two-em dash and horizontal ellipsis) usually occupy 2 em, making it easy to recognize and lay out. Some layout styles do not adjust the punctuation width at all. However, in order to make the the composition tighter and more readable, and when implementing [[[#prohibition_rules_for_line_start_end]]], the width of the punctuation marks needs to be adjusted. Whether to adjust depends on the judgment of the typesetting style. Many publications in Taiwan do not adjust punctuation width, while most publications in Mainland China and Hong Kong do adjust punctuation width. Punctuation width adjustment is usually divided into two situations: 1) when consecutive punctuation marks appear 2) when the punctuation mark appears at the beginning or end of a line. There are more than one style of width adjustment, and only the basic principles are explained below.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">标注在字间的标点符号（除乙式括号、破折号、省略号以外）通常占一个汉字宽度，使其易于识别、适合配置及排版，有些排版风格完全不对标点宽度进行任何调整。但是为了让文字体裁更加紧凑易读，以及执行[[[#prohibition_rules_for_line_start_end]]]时，就需要对标点符号的宽度进行调整。是否调整取决于对排版风格的判断，台湾的很多印刷品都采用不调整的风格；而在中国大陆和香港的出版物中，多数采取调整的风格。标点符号宽度调整通常分为两种情形：1. 标点符号连续出现 2.标点出现在行首或行尾。调整时的风格不尽相同，下文仅阐述基本原则。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">標註在字間的標點符號（除乙式括號、破折號、省略號以外）通常占一個漢字寬度，使其易於識別、適合配置及排版，有些排版風格完全不對標點寬度進行任何調整。但是為了讓文字體裁更加緊湊易讀，以及執行[[[#prohibition_rules_for_line_start_end]]]時，就需要對標點符號的寬度進行調整。是否調整取決於對排版風格的判斷，臺灣的很多印刷品都採用不調整的風格；而在中國大陸和香港的出版物中，多數採取調整的風格。標點符號寬度調整通常分為兩種情形：1. 標點符號連續出現 2.標點出現在行首或行尾。調整時的風格不盡相同，下文僅闡述基本原則。</p>
 
@@ -1965,7 +1965,7 @@ var respecConfig = {
           </figcaption>
         </figure>
 
-        <p its-locale-filter-list="en" lang="en">Unadjustable punctuations include: <abbr class="exclude" title="Guobiao standards">GB</abbr>-style short connector marks, interpuncts, and solidi, because these punctuation points always take half the width of a character; exclamation marks and question marks in horizontal writing mode in Hong Kong and Taiwan, and colons, semicolons, question marks, exclamation marks in vertical writing mode in Chinese Mainland, Hong Kong, and Taiwan, because these punctuations always take the width of a character.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">Unadjustable punctuations include: <abbr class="exclude" title="Guobiao standards">GB</abbr>-style short connector marks, interpuncts, and solidi, because these punctuation points always take 1/2 em; exclamation marks and question marks in horizontal writing mode in Hong Kong and Taiwan, and colons, semicolons, question marks, exclamation marks in vertical writing mode in Chinese Mainland, Hong Kong, and Taiwan, because these punctuations always take 1 em.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
           不可调整的标点包括：中国大陆GB式的半字连接号、间隔号、分隔号，因为这几个标点固定半个字宽；横排的港台式问号、感叹号和直排的冒号、分号、问号、感叹号（包括GB偏靠式和港台居中式），因为这几个标点固定一个字宽。
         </p>
@@ -1994,8 +1994,8 @@ var respecConfig = {
           無論文本整體採用何種風格，當夾注符號與其他符號連續排列時，或者夾注符號重復出現（如開始+開始，結束+結束，或者結束+開始）時，都應該進行原則上的調整，以使文字體裁更加緊湊、易讀。
         </p>
 
-        <p its-locale-filter-list="en" lang="en">
-          The adjustment in principle should be: if any two adjacent punctuation marks take 2 character widths, they should be reduced to 1.5 characters wide. Based on this principle, the typography style is allowed to be further adjusted so that the two punctuation marks take only 1 character width.
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          The adjustment in principle should be: if any two adjacent punctuation marks take 2 em, they should be reduced to 1.5 em. Based on this principle, the typography style is allowed to be further adjusted so that the two punctuation marks take only 1 character width.
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
           原则上的调整度应为：如果任意两个相邻标点符号占用2个字宽，应当缩减成1.5个字宽。在此原则上，允许排版风格进一步调整让两个符号只占1个字宽。
@@ -2143,7 +2143,7 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">In horizontal writing mode, the basic approach uses proportional fonts to represent Western text and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to one quarter of a Han character width, except at the line start or end.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">In horizontal writing mode, the basic approach uses proportional fonts to represent Western text and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4 em, except at the line start or end.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
       <div class="note" id="n036">
@@ -2181,7 +2181,7 @@ var respecConfig = {
           </figure>
         </li>
         <li id="id111">
-          <p its-locale-filter-list="en" lang="en"><span class="leadin">Setting Western letters with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Latin letters compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western letter or European numeral, up to a width of one quarter of a Han character, except at the line start or end.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western letters with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Latin letters compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western letter or European numeral, up to a width of 1/4 em, except at the line start or end.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">采用比例字体，将文字顺时针旋转90°配置。当文中的西文为一般单词、语句或四位数以上的阿拉伯数字时，采用此方法配置。汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">採用比例字體，將文字順時針旋轉90度配置。當文中的西字為一般單字詞、語句，或阿拉伯數在四位數以上時，採用此方法配置。漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
           <figure id="latin-90-clockwise-2">
@@ -2231,7 +2231,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">西文單字詞在可使用連字符處之外，不得分隔為兩行。</p>
         </li>
         <li id="id115">
-          <p its-locale-filter-list="en" lang="en">Tracking or spacing between a Han character and a Western letter or numeral is up to a quarter of the width of a Han character.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">Tracking or spacing between a Han character and a Western letter or numeral is up to 1/4 em.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母之间，原则上使用不多于四分之一个汉字宽的字距或空白。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母之間，原則上使用不多於四分之一個漢字寬的字距或空白。</p>
         </li>
@@ -2271,7 +2271,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
       <ol>
         <li id="id119">
-          <p its-locale-filter-list="en" lang="en">Instead of a quarter Han-width tracking between Han and Western letters, it is possible to use flexible spacing of up to half a Han character width. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han character before and after the Western language span snaps to the grid lines.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between Han and Western letters, it is possible to use flexible spacing of up to 1/2 em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han character before and after the Western language span snaps to the grid lines.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">汉字与西文字母间不使用四分之一汉字宽的字距，而是加入大于零、小于等于二分之一汉字宽的弹性空白，使西文所占的空间为汉字的整数倍，确保西文前后的汉字都能纵横对齐。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母間不使用四分之一漢字寬之字距，而是加入大於零、小於等於二分之一漢字寬的彈性空白，使西文所佔之空間為漢字的整數倍，確保西文前後之漢字都能縱橫對齊。</p>
         </li>
@@ -3244,8 +3244,8 @@ var respecConfig = {
 
       <ol type="a">
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            At the end of a line: adjusted to fixed half a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            At the end of a line: adjusted to fixed 1/2 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行末的标点。调成固定的半个汉字宽。
@@ -3267,8 +3267,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Spacing between Western texts: for lines with numerous instances of Western text, their spacing should be processed at the same time, with equal treatment. The minimum space between each Western text should be quarter of a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Spacing between Western texts: for lines with numerous instances of Western text, their spacing should be processed at the same time, with equal treatment. The minimum space between each Western text should be 1/4 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最小可以挤压到四分之一汉字宽。
@@ -3279,8 +3279,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Interpuncts: space reduction must take place equally on both sides of the character. The minimum space is 0, whereby the interpunct ends up being half a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Interpuncts: space reduction must take place equally on both sides of the character. The minimum space is 0, whereby the interpunct ends up being 1/2 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的间隔号。挤压时必须同时从字面两侧、同等量处理，最小挤到0，即变成半个汉字字宽。
@@ -3291,8 +3291,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Brackets: space reduction can take place before the opening bracket and after the closing bracket. If multiple brackets occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the bracket is half a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Brackets: space reduction can take place before the opening bracket and after the closing bracket. If multiple brackets occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the bracket is 1/2 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的夹注符号。可以对开始夹注符号的前侧、结束夹注符号的后侧进行挤压，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
@@ -3303,8 +3303,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Commas, secondary commas and semi-colons: space reduction should follow [[[#h-punctuation_adjustment_space]]]. Spacing can be reduced at the end of the punctuation mark or equally on either side. If multiple of such punctuations occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the punctuation mark is half a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Commas, secondary commas and semi-colons: space reduction should follow [[[#h-punctuation_adjustment_space]]]. Spacing can be reduced at the end of the punctuation mark or equally on either side. If multiple of such punctuations occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the punctuation mark is 1/2 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的逗号、顿号、分号。挤压空间依照[[[#h-punctuation_adjustment_space]]]，可以是后侧，也可以是字面两侧同时，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
@@ -3315,8 +3315,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Spacing between Han characters and Western texts: if there are numerous instances of mixed texts, space reduction should be processed at the same time, with equal treatment, with the minimum space being one-eighth of a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Spacing between Han characters and Western texts: if there are numerous instances of mixed texts, space reduction should be processed at the same time, with equal treatment, with the minimum space being 1/8 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             行内的中西间距，最小挤为八分之一汉字宽。一行内若有多处，应该同时、同等量处理。
@@ -3325,8 +3325,8 @@ var respecConfig = {
             行內的中西間距，最小擠為八分之一漢字寬。一行內若有多處，應該同時、同等量處理。
           </p>
           <aside class="note">
-            <p its-locale-filter-list="en" lang="en">
-              Certain typesetting styles have a fixed default spacing between Han characters and Western texts, for example a quarter of a character width, in such cases, adjustment is not allowed.
+            <p its-locale-filter-list="en" lang="en" class="checkme">
+              Certain typesetting styles have a fixed default spacing between Han characters and Western texts, for example 1/4 em, in such cases, adjustment is not allowed.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被挤压。
@@ -3338,8 +3338,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Periods, question marks and exclamation marks: in accordance to [[[#h-punctuation_adjustment_space]]], if there is available space, spacing can be reduced up until the minimum size of half a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Periods, question marks and exclamation marks: in accordance to [[[#h-punctuation_adjustment_space]]], if there is available space, spacing can be reduced up until the minimum size of 1/2 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             位于行内的句号、问号、感叹号。依照[[[#h-punctuation_adjustment_space]]]，如果有调整空间则可以挤压，最小挤为半个汉字字宽。
@@ -3348,8 +3348,8 @@ var respecConfig = {
             位於行內的句號、問號、驚嘆號。依照[[[#h-punctuation_adjustment_space]]]，如果有調整空間則可以擠壓，最小擠為半個漢字字寬。
           </p>
           <aside class="note">
-            <p its-locale-filter-list="en" lang="en">
-              As these punctuation marks indicate a longer pause at the end of a sentence, certain typesetting styles do not allow line adjustment to be made on them, maintaining their width to be one character width.
+            <p its-locale-filter-list="en" lang="en" class="checkme">
+              As these punctuation marks indicate a longer pause at the end of a sentence, certain typesetting styles do not allow line adjustment to be made on them, maintaining their width to be 1 em.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               由于句末标点表示停顿较大，因此有些排版风格禁止此项调整，而保持句号、问号、感叹号固定一个字宽。
@@ -3381,8 +3381,8 @@ var respecConfig = {
 
       <ol type="a">
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Word spacing between Western texts: for lines with several Western word spaces, these should be processed at the same time, with equal treatment. Each word space can be expanded to a maximum of half a character width.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Word spacing between Western texts: for lines with several Western word spaces, these should be processed at the same time, with equal treatment. Each word space can be expanded to a maximum of 1/2 em.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最大可以拉伸到半个汉字字宽。
@@ -3393,8 +3393,8 @@ var respecConfig = {
         </li>
 
         <li>
-          <p its-locale-filter-list="en" lang="en">
-            Space between Han characters and Western texts can be expanded from the default width (e.g., a quarter character width). They should be processed at the same time, with equal treatment.
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Space between Han characters and Western texts can be expanded from the default width (e.g., 1/4 em). They should be processed at the same time, with equal treatment.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
             行内的中西间距，从默认宽度（如四分之一汉字宽）开始拉伸，一行内若有多处，应该同时、同等量处理，最大可拉大到半个汉字字宽。
@@ -3403,8 +3403,8 @@ var respecConfig = {
             行內的中西間距，從默認寬度（如四分之一漢字寬）開始拉伸，一行內若有多處，應該同時、同等量處理，最大可拉大到半個漢字字寬。
           </p>
           <aside class="note">
-            <p its-locale-filter-list="en" lang="en">
-              Numerous typesetting styles practically only allow expansion of space up to a third of a character width. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example a quarter of a character width, in such cases, adjustments are not allowed.
+            <p its-locale-filter-list="en" lang="en" class="checkme">
+              Numerous typesetting styles practically only allow expansion of space up to 1/3 em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example a quarter of a character width, in such cases, adjustments are not allowed.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               很多排版风格在实际处理上，只允许最大拉伸到三分之一汉字宽。与上述挤压处理一样，在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被拉伸。

--- a/index.html
+++ b/index.html
@@ -2625,8 +2625,8 @@ var respecConfig = {
           </li>
           <li id="id138">
             <p its-locale-filter-list="en" lang="en">The space between two adjacent annotations should not be smaller than the size of a normal Western-language space, which is about 1/4 em. Due to the limitation of typesetting technologies, there is usually no space between the rather long phonetic annotations in many printed publications. Luckily, this is not likely to lead to ambiguity because each Han character contains one syllable and most Pinyin fragments are easy to tell apart. However, these annotations can be misleading sometimes. For example, character-based phonetic annotations may result in the false impression that they are word-based. Also, the accidentally concatenated annotations may disrupt word boundaries, which alters the semantic meanings of the words.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">相邻注文的间距不应小于西文词间空格的宽度（约 1/4em）。但受排版技术限制，许多出版物中过长的相邻注文都会紧密相连。因汉字为单音节文字且多数汉语拼音音节都容易辨认界限，并不容易出现标音的歧义，但由于每个汉字的标音都已隔开，意外的相连易造成分词连写的假象，且相连的标音时常横跨词界，打乱语义。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">相鄰注文的間距不應小於西文詞間空格的寬度（約1/4em）。但受排版技術限制，許多出版物中過長的相鄰注文都會緊密相連。因漢字為單音節文字且多數漢語拼音音節都容易辨認界限，並不容易出現標音的歧義，但由於每個漢字的標音都已隔開，意外的相連易造成分詞連寫的假象，且相連的標音時常橫跨詞界，打亂語義。</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">相邻注文的间距不应小于西文词间空格的宽度（约1/4字宽）。但受排版技术限制，许多出版物中过长的相邻注文都会紧密相连。因汉字为单音节文字且多数汉语拼音音节都容易辨认界限，并不容易出现标音的歧义，但由于每个汉字的标音都已隔开，意外的相连易造成分词连写的假象，且相连的标音时常横跨词界，打乱语义。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">相鄰注文的間距不應小於西文詞間空格的寬度（約1/4字寬）。但受排版技術限制，許多出版物中過長的相鄰注文都會緊密相連。因漢字為單音節文字且多數漢語拼音音節都容易辨認界限，並不容易出現標音的歧義，但由於每個漢字的標音都已隔開，意外的相連易造成分詞連寫的假象，且相連的標音時常橫跨詞界，打亂語義。</p>
           </li>
           <li id="id139">
             <p its-locale-filter-list="en" lang="en">Annotations are allowed to extend over the top of the adjacent base text as long as the minimum spacing is ensured.</p>
@@ -2712,8 +2712,8 @@ var respecConfig = {
           </li>
           <li id="id150">
             <p its-locale-filter-list="en" lang="en">Both the phonetic annotations and the base text are separated at word boundaries. The adjacent annotations are separated by an approximately 1/2 em wide space, while the tracking inside the base text is usually normal.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">正文与标音双方皆分词连写。相邻基文之间有约1/2em的空格隔开，基文内部字距通常正常。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">正文與標音雙方皆分詞連寫。相鄰基文之間有約1/2em的空格隔開，基文內部字距通常正常。</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">正文与标音双方皆分词连写。相邻基文之间有约1/2字宽的空格隔开，基文内部字距通常正常。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">正文與標音雙方皆分詞連寫。相鄰基文之間有約1/2字寬的空格隔開，基文內部字距通常正常。</p>
           </li>
           <li id="id151">
             <p its-locale-filter-list="en" lang="en">Many word-based annotations indicate the logic of the whole sentence, rather than merely the pronunciation: these phonetic annotations have capitalized sentences and capitalized proper names. Punctuation may also be included in these annotations, but is kept with a preceding annotation, as shown in [[[#group-ruby]]], and doesn't appear over the punctuation in the base text.</p>

--- a/index.html
+++ b/index.html
@@ -1239,7 +1239,7 @@ var respecConfig = {
                   <p its-locale-filter-list="en" lang="en">Set horizontally without changing orientation (like <a href="https://w3c.github.io/jlreq/#handling_of_tatechuyoko">tate-chu-yoko</a> in Japanese). This is usually applied to numbers comprising two to three digits.</p>
                   <p its-locale-filter-list="zh-hans" lang="zh-hans">保持正常方向，横排处理（如日文的<a href="https://w3c.github.io/jlreq/#handling_of_tatechuyoko">纵中横排</a>）。主要应用于二至三位数字。</p>
                   <p its-locale-filter-list="zh-hant" lang="zh-hant">保持正常方向，橫排處理（如日文的<a href="https://w3c.github.io/jlreq/#handling_of_tatechuyoko">縱中橫排</a>）。主要應用於二至三位數字。</p>
-                  <p its-locale-filter-list="en" lang="en">In principle, if numbers are arranged horizontally in a vertical writing mode, the width of the numbers should not exceed one character width. This rule originated in the letterpress printing era due to the fixed width of each line. Therefore, in vertical writing mode, Western text or <a href="#term.european-numerals" class="termref">European numerals</a> are not limited to two digits, but the width should not exceed one character width. Some commonly seen examples include "3.0", "A+" and "2B".</p>
+                  <p its-locale-filter-list="en" lang="en" class="checkme">In principle, if numbers are arranged horizontally in a vertical writing mode, the width of the numbers should not exceed 1 em. This rule originated in the letterpress printing era due to the fixed width of each line. Therefore, in vertical writing mode, Western text or <a href="#term.european-numerals" class="termref">European numerals</a> are not limited to two digits, but the width should not exceed 1 em. Some commonly seen examples include "3.0", "A+" and "2B".</p>
                   <p its-locale-filter-list="zh-hans" lang="zh-hans">数字在直排行内横排，原则上不超过一个汉字的字幅。这是从活字印刷时代起，每行宽度固定所致。故直排时，西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>横排不限于两位数，但原则上不能超过一个汉字。现代常见的用法还包括[3.0]、[A+]、[2B]等。</p>
                   <p its-locale-filter-list="zh-hant" lang="zh-hant">數字於直排行內橫排，原則上不超過一個漢字的字幅。這是從活字印刷時代起，每行寬度固定所致。故直排時，西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>橫排不限於二位數，但原則上不能超過一個漢字。現代常見的用法還包括[3.0]、[A+]、[2B]等。</p>
                 </li>
@@ -1648,13 +1648,13 @@ var respecConfig = {
       <p its-locale-filter-list="en" lang="en">Connector marks should take up the same dimensions as a single character, and be vertically and horizontally centered within its square frame. Among the connector marks, the EN DASH should have a short length to distinguish it from the Chinese character [一], which means one. And they should be positioned in the same direction as the characters they mark.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">连接号位于字面正中，占一个汉字的大小，其中，甲式连接号在横排时，符号的直线长度应稍小于汉字“一”以避免歧义，按照文字书写方向使用相应的标注方向。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">連接號位字面正中，佔一個漢字的大小，其中，甲式連接號在橫排時，符號的直線長度應稍小於漢字「一」以避免歧義，依文字書寫方向使用相應的標注方向。</p>
-      <p its-locale-filter-list="en" lang="en">Middle dots should be vertically and horizontally centered within their square frame. To make more economical use of the available space, or to tighten the overall spacing, sometimes the solidus can have a half character width.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Middle dots should be vertically and horizontally centered within their square frame. To make more economical use of the available space, or to tighten the overall spacing, sometimes the solidus can have 1/2 em.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号位于字面正中，占一个汉字的大小，直、横排方向一致。为了节省排版空间、使词组或数字较紧凑地排列，可以使用半个汉字大小的间隔号。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">間隔號位於字面正中，佔一個漢字的大小，直、橫排方向一致。為了節省排版空間、使詞組或數字較緊湊地排列，可以使用半個漢字大小的間隔號。</p>
       <p its-locale-filter-list="en" lang="en">Interlinear marks like proper noun marks, book title mark type A, and emphasis dots should be positioned underneath the marked characters in horizontal writing mode. In vertical writing mode, emphasis dots should be positioned to the right side of the marked characters so as not to affect the characters above and beneath them.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">标注在行间的标号需以不影响上下行文字为原则进行配置。包括：专名号、甲式书名号等两个符号，位于被标注文字底端（横排位于文字下方、直排位于文字左侧）；着重号横排时位于文字底端（下方）、直排时位于文字顶端（右侧）。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">標注於行間的標號需以不影響上下行文字為原則進行配置。包括：專名號、甲式書名號等二個符號，位受注文字底端（橫排位文字下方、直排位文字左側）；着重號橫排時位受注文字底端（下方）、直排時位在受注文字頂端（右側）。</p>
-      <p its-locale-filter-list="en" lang="en">Solidi should be vertically and horizontally centered within their square frame. As GB rules, it should take half a character width, whereas in Taiwan, there is no clear rule about its dimensions but most publications will give them the same dimensions as a single character.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Solidi should be vertically and horizontally centered within their square frame. As GB rules, it should take 1/2 em, whereas in Taiwan, there is no clear rule about its dimensions but most publications will give them the same dimensions as a single character.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">分隔号位于字面正中，中国大陆的国标规定排版时占半个汉字的大小；而在台湾则未有相关的规定，但多数出版品使用一个汉字的大小。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">分隔號位於字面正中，中國大陸的國標規定排版時佔半個漢字的大小；而在台灣則未有相關的規定，但多數出版品使用一個漢字的大小。</p>
       <p its-locale-filter-list="en" lang="en">
@@ -1714,7 +1714,7 @@ var respecConfig = {
         <p its-locale-filter-list="en" lang="en">Exclamatory question marks are defined in the General Rules for Punctuation (GB/T 15834—2011) as an extended usage of exclamation marks. For questions with a strong exclamatory tone of voice, it is appropriate to add an exclamation mark after the question mark (?!). However, it is common to see a question mark added after an exclamation mark (!?) in numerous publications as well. In addition, <abbr class="exclude" title="Guobiao standards">GB</abbr> rules indicate that it is acceptable to chain up to 3 exclamation marks or question marks in succession (!!!, ???) for exclamatory statements or interrogative sentences which require greater emphasis.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">叹问号于中国大陆《标点符号用法》（GB/T 15834—2011）中作为叹号的延伸用法，当语气同时具备强烈的疑问与感叹时，可于问号后加上叹号（?!）。然而在许多作品中，也常见在叹号后加上问号（!?）的用法。此外，在同标准的问号与叹号用法也指明在语气加重时可叠用问号或者叹号，最多可叠用到三个（!!!、???）。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">嘆問號於中國大陸《標點符號用法》（GB/T 15834—2011）中作為嘆號的延伸用法，當語氣同時具備強烈的疑問與感嘆時，可於問號後加上嘆號（?!）。然而在許多作品中，也常見在嘆號後加上問號（!?）的用法。此外，在同標準的問號與嘆號用法也指明在語氣加重時可疊用問號或者嘆號，最多可疊用到三個（!!!、???）。</p>
-        <p its-locale-filter-list="en" lang="en">In print publications, <abbr class="exclude" title="Guobiao standards">GB</abbr> rules state that when question marks and exclamation marks are chained, they are considered one character width. Double question marks or double exclamation marks also one character width. Triple question marks or triple exclamation marks are two character widths. In addition, for vertical writing mode in Taiwan, chained question marks or exclamation marks are upright and take up one character width.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">In print publications, <abbr class="exclude" title="Guobiao standards">GB</abbr> rules state that when question marks and exclamation marks are chained, they are considered 1 em. Double question marks or double exclamation marks also 1 em. Triple question marks or triple exclamation marks are 2 em. In addition, for vertical writing mode in Taiwan, chained question marks or exclamation marks are upright and take up 1 em.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">排版上，《标点符号用法》规定问号与叹号连用时，占一个字位置；两个问号或叹号叠用时，占一个字位置；三个问号或叹号叠用时，占两个字位置。此外，在台湾直排的习惯中，叹问号连用与问号、叹号叠用时，符号多直立，并且占一个字的位置。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">排版上，《標點符號用法》規定問號與嘆號連用時，佔一個字位置；兩個問號或嘆號疊用時，佔一個字位置；三個問號或嘆號疊用時，佔兩個字位置。此外，在台灣直排的習慣中，嘆問號連用與問號、嘆號疊用時，符號多直立，並且佔一個字的位置。</p>
         <div class="note">
@@ -1883,7 +1883,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en">The following punctuation marks should be considered as one unit and take two character widths. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2 em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，在行间应为一体，视作一个字符存在，不能为了适配分行而拆成两行。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，在行間應為一體，視作一個字元存在，不得以適配分行之由拆至二行。</p>
         <ol>
@@ -1891,7 +1891,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Two-em dash.</span></p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">乙式括号与破折号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">乙式括號與破折號</span></p>
-            <p its-locale-filter-list="en" lang="en">Two-em dashes [<span lang="zh">——</span>] can be created using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [<span lang="zh">⸺</span>] or two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [<span lang="zh">—</span>] characters. Both alternatives should take two character widths.</p>
+            <p its-locale-filter-list="en" lang="en" class="checkme">Two-em dashes [<span lang="zh">——</span>] can be created using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [<span lang="zh">⸺</span>] or two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [<span lang="zh">—</span>] characters. Both alternatives should take 2 em.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">乙式括号与破折号是占两个汉字空间的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] 或连续使用两个<span class="uname" translate="no">U+2014 EM DASH</span> [—]。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">乙式括號與破折號為佔二個漢字空間的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] 或連續使用兩個<span class="uname" translate="no">U+2014 EM DASH</span> [—]。</p>
           </li>
@@ -1995,7 +1995,7 @@ var respecConfig = {
         </p>
 
         <p its-locale-filter-list="en" lang="en" class="checkme">
-          The adjustment in principle should be: if any two adjacent punctuation marks take 2 em, they should be reduced to 1.5 em. Based on this principle, the typography style is allowed to be further adjusted so that the two punctuation marks take only 1 character width.
+          The adjustment in principle should be: if any two adjacent punctuation marks take 2 em, they should be reduced to 1.5 em. Based on this principle, the typography style is allowed to be further adjusted so that the two punctuation marks take only 1 em.
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
           原则上的调整度应为：如果任意两个相邻标点符号占用2个字宽，应当缩减成1.5个字宽。在此原则上，允许排版风格进一步调整让两个符号只占1个字宽。
@@ -2836,7 +2836,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans">为使不同的文本形成意义上的区隔、构成段落，呈现上，会使用断行以标示一个段落的起始，同时也会在段落首行加上空白进行缩排（也称为缩进），原则上以文本的汉字大小作为缩排单位，主要呈现方法如下。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">為使不同的文本形成意義上的區隔、構成段落，呈現上，會使用斷行以標示一個段落的起始，同時也會在段落首行加上空白進行縮排（也稱為縮進），原則上以文本的漢字大小作為縮排單位，主要呈現方法如下。</p>
       <div class="note" id="n046">
-        <p its-locale-filter-list="en" lang="en" class="checkme">For Chinese publications, a first-line indent usually uses two character width spaces. Publications like magazines, with multi-column content and less text in each column, might apply single character width first-line indents as well.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">For Chinese publications, a first-line indent usually uses 2-em spaces. Publications like magazines, with multi-column content and less text in each column, might apply 1-em first-line indents as well.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">中文出版品上，段首缩排以两个汉字的空间为标准。若遇到杂志等多栏排版的情况，每栏字数较少时，视觉上缩排两字将显突兀，时有改用缩排一字的做法。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">中文出版品上，段首縮排以兩個漢字的空間為標準。若遇到雜誌等多欄排版的情況，每欄字數較少時，視覺上縮排兩字將顯突兀，時有改用縮排一字的做法。</p>
       </div>
@@ -3255,7 +3255,7 @@ var respecConfig = {
           </p>
           <aside class="note">
             <p its-locale-filter-list="en" lang="en">
-              In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up half a character width for a more pleasing aesthetic.
+              In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up 1/2 em for a more pleasing aesthetic.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定“5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。”
@@ -3404,7 +3404,7 @@ var respecConfig = {
           </p>
           <aside class="note">
             <p its-locale-filter-list="en" lang="en" class="checkme">
-              Numerous typesetting styles practically only allow expansion of space up to 1/3 em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example a quarter of a character width, in such cases, adjustments are not allowed.
+              Numerous typesetting styles practically only allow expansion of space up to 1/3 em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example 1/4 em, in such cases, adjustments are not allowed.
             </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">
               很多排版风格在实际处理上，只允许最大拉伸到三分之一汉字宽。与上述挤压处理一样，在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被拉伸。
@@ -3817,7 +3817,7 @@ var respecConfig = {
           <td>203C</td>
           <td>DOUBLE EXCLAMATION MARK</td>
           <td>
-            <p its-locale-filter-list="en" lang="en">Takes one character width.
+            <p its-locale-filter-list="en" lang="en" class="checkme">Takes 1 em.
             <p its-locale-filter-list="zh-hans" lang="zh-hans">占一个汉字大小。
             <p its-locale-filter-list="zh-hant" lang="zh-hant">佔一個漢字大小。
           </td>
@@ -3839,7 +3839,7 @@ var respecConfig = {
           <td>2047</td>
           <td>DOUBLE QUESTION MARK</td>
           <td>
-            <p its-locale-filter-list="en" lang="en">Takes one character width.
+            <p its-locale-filter-list="en" lang="en" class="checkme">Takes 1 em.
             <p its-locale-filter-list="zh-hans" lang="zh-hans">占一个汉字大小。
             <p its-locale-filter-list="zh-hant" lang="zh-hant">佔一個漢字大小。
           </td>


### PR DESCRIPTION
To resolve #465:

- In Simplified Chinese and Traditional Chinese, change `em` into `字宽`/`字寬`.
- In English, translate `字宽`/`字寬` or `汉字字宽`/`漢字字寬` into `em` when used as units.
- In English, reword `character width(s)` into `em` when used to describe length, gap, or spacing.
- Add or replace the spaces between numeric value and `em` unit with non-breaking spaces per [#452](https://github.com/w3c/clreq/issues/452) & [#464](https://github.com/w3c/clreq/pull/464#issuecomment-1129513227)
- Mark the revised English lines as `checkme`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/466.html" title="Last updated on May 20, 2022, 2:42 AM UTC (2bbb08b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/466/06f9a70...realfish:2bbb08b.html" title="Last updated on May 20, 2022, 2:42 AM UTC (2bbb08b)">Diff</a>