### PR TITLE
Add explicit width and height on images

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@ var respecConfig = {
         </h5>
 
         <figure id="fig-loose-setting">
-          <span style="text-align:center;"><img src="images/en/increased-inter-character-spacing.svg" alt="Examples of loose setting in horizontal writing mode." width="600"></span>
+          <span style="text-align:center;"><img src="images/en/increased-inter-character-spacing.svg" alt="Examples of loose setting in horizontal writing mode." width="600" height="209"></span>
           <figcaption>
             <span its-locale-filter-list="en" lang="en">Examples of loose setting in horizontal writing mode.</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">疏排</span>
@@ -428,7 +428,7 @@ var respecConfig = {
         </h5>
 
         <figure id="fig-negative-tracking">
-          <span style="text-align:center;"><img src="images/zh/negative-tracking.svg" alt="Example of reduced inter-character spacing in horizontal writing mode." width="600"></span>
+          <span style="text-align:center;"><img src="images/zh/negative-tracking.svg" alt="Example of reduced inter-character spacing in horizontal writing mode." width="600" height="110"></span>
           <figcaption>
             <span its-locale-filter-list="en" lang="en">Reduced inter-character spacing</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">紧排</span>
@@ -501,7 +501,7 @@ var respecConfig = {
       </h4>
 
       <figure id="fig-song">
-        <span style="text-align:center;"><img src="images/zh/songti.svg" alt="Samples of Song" width="800"></span>
+        <span style="text-align:center;"><img src="images/zh/songti.svg" alt="Samples of Song" width="800" height="380"></span>
         <figcaption>
           <span its-locale-filter-list="en" lang="en">Song</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">宋体</span>
@@ -526,7 +526,7 @@ var respecConfig = {
       </h4>
 
       <figure id="fig-kai">
-        <span style="text-align:center;"><img src="images/zh/kaiti.svg" alt="Samples of Kai" width="800"></span>
+        <span style="text-align:center;"><img src="images/zh/kaiti.svg" alt="Samples of Kai" width="800" height="380"></span>
         <figcaption>
           <span its-locale-filter-list="en" lang="en">Kai</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">楷体</span>
@@ -558,7 +558,7 @@ var respecConfig = {
       </h4>
 
       <figure id="fig-hei">
-        <span style="text-align:center;"><img src="images/zh/heiti.svg" alt="Samples of Hei" width="800"></span>
+        <span style="text-align:center;"><img src="images/zh/heiti.svg" alt="Samples of Hei" width="800" height="380"></span>
         <figcaption>
           <span its-locale-filter-list="en" lang="en">Hei</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">黑体</span>
@@ -591,7 +591,7 @@ var respecConfig = {
       </h4>
 
       <figure id="fig-fangsong">
-        <span style="text-align:center;"><img src="images/zh/fangsong.svg" alt="Samples of Fangsong" width="800"></span>
+        <span style="text-align:center;"><img src="images/zh/fangsong.svg" alt="Samples of Fangsong" width="800" height="380"></span>
         <figcaption>
           <span its-locale-filter-list="en" lang="en">Fangsong (Imitation Song)</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">仿宋体</span>
@@ -650,7 +650,7 @@ var respecConfig = {
     <p its-locale-filter-list="en" lang="en" class="checkme">The <a href="#term.type-area" class="termref">type area</a>, sometimes called the printing area, is the rectangle in the middle of the page that contains the main body of the text. The text in the type area can be divided into two or more independent parts according to the reading direction of the text. Each independent part is called a "column", and this type of division is called a "multi-column layout".</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.type-area" class="termref">版心</a>是页面中间包含文本的主体的矩形区域。版心里的文字，可以按照文字阅读方向分割成两个或者更多的独立部分，每个独立部分称为“栏”，而这种分割版式叫“分栏”，根据一页里栏数，可以具体地称为“双栏”“三栏”等各种方式；相对地，将文字直接按照基本版式填满版心、不分栏的方式也可成为“通栏”。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.type-area" class="termref">版心</a>是頁面中間包含文本的主體的矩形區域。版心裏的文字，可以按照文字閱讀方向分割成兩個或者更多的獨立部分，每個獨立部分稱為“欄”，而這種分割版式叫“分欄”，根據一頁裏欄數，可以具體地稱為“雙欄”“三欄”等各種方式；相對地，將文字直接按照基本版式填滿版心、不分欄的方式也可成為“通欄”。</p>
-    
+
     <p its-locale-filter-list="en" lang="en" class="checkme">Although books tend to use one template for their page format, some further design effort will be needed to extend that template for pages such as the table of contents and indexes. Furthermore, there are many examples of indexes with a different page format than the basic page format, and vertically set books often have indexes in horizontal writing mode, and sometimes multiple columns. This still holds true where the goal is to make the size of the basic page template for indexes close to the size of basic page template in the basic page format.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">尽管书籍通常仅使用一种排版样式（即“基本版式”），在实际页面的设计上，如目录、索引等页面，会基于基本版式重新设计。索引等页面采用不同排版样式设计的案例也相当多，直排书索引也会以横排或者多栏排版等方式设计。尽管如此，索引的版心尺寸仍应与基本版式近似。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">盡管書籍通常僅使用一種排版樣式（即“基本版式”），在實際頁面的設計上，如目錄、索引等頁面，會基於基本版式重新設計。索引等頁面採用不同排版樣式設計的案例也相當多，直排書索引也會以橫排或者多欄排版等方式設計。盡管如此，索引的版心尺寸仍應與基本版式近似。</p>
@@ -1512,7 +1512,7 @@ var respecConfig = {
               <p its-locale-filter-list="en" lang="en">Chapter 6.2 of v14 of the Unicode Standard suggests using <span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯] for ellipses.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">在Unicode标准第14版的6.2章中，也推荐使用<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]作为省略号。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">在Unicode標準第14版的6.2章中，亦推薦使用<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]作為刪節號。</p>
-              
+
               <p its-locale-filter-list="en" lang="en">This code point, with appropriate rotation and replacement mechanism, will be centered within its character frame regardless of whether it is in vertical or horizontal writing mode, which is more in line with the Chinese typesetting requirements.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">此符号配合适当的转向与取代机制，在显示上无论直横排，省略点皆居中，更符合排版需求。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">此符號配合適當的轉向與取代機制，在顯示上無論直橫排，刪節點皆居中，更符合排版需求。</p>
@@ -1635,7 +1635,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">點號，包括：頓號、逗號、分號、冒號、句號、問號、驚嘆號等，佔一個漢字的大小，直、橫排方向一致。港台的排版位於字面正中；中國大陸的排版則位受注文字末端、字面始端偏頂端或底端一側（橫排時位字面左下角，直排時位字面右上角）。</p>
 
       <figure id="region-specific-punctuation-example">
-        <img width="300" alt="GB/T 15834規定的標點位置" src="images/zh/locale_punctuation.png">
+        <img width="250" height="205" alt="GB/T 15834規定的標點位置" src="images/zh/locale_punctuation.png">
         <figcaption><span its-locale-filter-list="en" lang="en">An example punctuation position for vertical writing mode in Mainland China</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中国大陆竖排标点位置示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">中國大陸直排標點位置範例。</span></figcaption>
       </figure>
 
@@ -1735,7 +1735,7 @@ var respecConfig = {
         <p its-locale-filter-list="en" lang="en">The symbol of death is not defined in the <abbr class="exclude" title="Guobiao standards">GB</abbr> rules, but is a punctuation mark which is widely used by the commons. The symbol of death is a solid black border outside the character frame of a person's name to indicate the person is deceased. Its Western counterpart would be the dagger punctuation mark (U+2020 DAGGER † and U+2021 DOUBLE DAGGER ‡).</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">示亡号并未列于标点符号相关标准文件，但却是民间经常使用的俗用符号。示亡号亦称示殁号，为在人名文字外框描上实心的黑色边线表示已经过世，类似西文中剑标（U+2020 DAGGER †与U+2021 DOUBLE DAGGER ‡）之用法。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">示亡號並未列於標點符號相關標準文件，但卻是民間經常使用的俗用符號。示亡號亦稱示殁號，為在人名文字外框描上實心的黑色邊線表示已經過世，類似西文中劍標（U+2020 DAGGER †與U+2021 DOUBLE DAGGER ‡）之用法。</p>
-        <figure id="death-symbol-use-case"><img width="600" alt="示亡号示例" src="images/zh/symbol-of-death.png">
+        <figure id="death-symbol-use-case"><img width="600" height="138" alt="示亡号示例" src="images/zh/symbol-of-death.png">
           <figcaption><span its-locale-filter-list="en" lang="en">An example of the usage of symbol of death</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">示亡号用法的示例。</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">示亡號用法的示例。</span></figcaption>
@@ -1955,9 +1955,9 @@ var respecConfig = {
         <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號分為「不可調整」和「可調整」兩類，「可調整」再根據調整空間分為六類：橫排字面左、橫排字面右、橫排左右兩側；直排字面上、直排字面下、直排上下兩側。</p>
 
         <figure id="fig_punctuation_adjustment_space">
-          <img its-locale-filter-list="en" lang="en" height="300" alt="Punctuation adjustment space" src="images/en/punctuation-adjustment-space.png">
-          <img its-locale-filter-list="zh-hans" lang="zh-hans" height="300" alt="标点符号的调整空间" src="images/zh/punctuation-adjustment-space-hans.png">
-          <img its-locale-filter-list="zh-hant" lang="zh-hant" height="300" alt="標點符號的調整空間" src="images/zh/punctuation-adjustment-space-hant.png">
+          <img its-locale-filter-list="en" lang="en" width="800" height="655" alt="Punctuation adjustment space" src="images/en/punctuation-adjustment-space.png">
+          <img its-locale-filter-list="zh-hans" lang="zh-hans" width="800" height="655" alt="标点符号的调整空间" src="images/zh/punctuation-adjustment-space-hans.png">
+          <img its-locale-filter-list="zh-hant" lang="zh-hant" width="800" height="655" alt="標點符號的調整空間" src="images/zh/punctuation-adjustment-space-hant.png">
           <figcaption>
             <span its-locale-filter-list="en" lang="en">Adjustment space of punctuation marks.</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的调整空间。</span>
@@ -2337,7 +2337,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Mandarin Phonetic Symbols (國語注音符號) or Taiwanese Dialect Phonetic Symbols (台灣方音符號), hereinafter referred to as ‘Zhuyin’, are systems for phonetic annotation mainly used in Taiwan, although other areas may also include Zhuyin in certain dictionaries or textbooks. In most cases, Zhuyin appears on the right side of its corresponding base text. Exceptions are very rare.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">国语注音符号及台湾方音符号（以下统称注音或注音符号）标音系统多用于台湾，其他地区仅见于特定的辞典或教科书中。绝大多数的情况下，注音符号标注于相应汉字（基文）的右侧，例外情况非常少见。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">國語注音符號及台灣方音符號（以下統稱注音或注音符號）標音系統多用於台灣，其他地區僅見於特定的辭典或教科書中。絕大多數的情況下，注音符號標注於相應漢字（基文）的右側，例外情況非常少見。</p>
-            <figure id="zhuyin-use-case"><img height="300" alt="文字直排下，注音符號行間注排版示例" src="images/zh/zhuyin-use-case-vertical.svg"> <img width="300" alt="文字橫排下，注音符號行間注排版示例" src="images/zh/zhuyin-use-case-horizontal.svg">
+            <figure id="zhuyin-use-case"><img height="300" width="163" alt="文字直排下，注音符號行間注排版示例" src="images/zh/zhuyin-use-case-vertical.svg"> <img width="300" height="105" alt="文字橫排下，注音符號行間注排版示例" src="images/zh/zhuyin-use-case-horizontal.svg">
               <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for Zhuyin in vertical and horizontal writing modes.</span>
               <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号在直、横排下的行间注排版示例。</span>
               <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號在直、橫排下的行間注排版示例。</span></figcaption>
@@ -2353,7 +2353,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Due to the characteristics of the Latin alphabet, such annotations appear in horizontal writing mode only. Texts for children who are native speakers usually provide reading assistance for each individual character, while texts for those who are learning Chinese as a second language mainly indicate pronunciation for whole words, but occasionally, both of them are set almost the same. There is space between the base text when whole words are annotated, and the interlinear annotation characters will have unique requirements such as sentence case, or punctuation marks corresponding to base characters. The composition of early publications using pinyin was quite variable and not consistent. In general, both character-based and word-based annotations were quite common. No further description of the early pinyin will be found in this document.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">因拉丁字母的特质，此类标音文本仅横排。针对幼儿母语者的文本以单字作为基文进行标音。针对双语学习者的文本除偶有与前者一致的格式外，大多分词连写，以词作为基文进行标音，基文之间如西文书写一般用空格隔开，并且注文有句首大写、专名首字母大写等格式以及与正文对应的标点符号，自成一体。汉语拼音早期印刷品的格式较为多变，一致性不强。大体上，单字标音与分词连写标音都常见，不作详细述。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">因拉丁字母的特質，此類標音文本僅橫排。針對幼兒母語者的文本以單字作為基文進行標音。針對二語學習者的文本除偶有與前者一致的格式外，大多分詞連寫，以詞作為基文進行標音，基文之間如西文書寫般用空格隔開，並且注文有句首大寫、專名首字母大寫等格式以及與正文對應的標點符號，自成一體。漢語拼音早期印刷品的格式較為多變，一致性不強。大體上，單字標音與分詞連寫標音都常見，不作詳細描述。</p>
-            <figure id="pinyin-use-case"><img width="300" alt="羅馬拼音行間注的排版示例" src="images/zh/pinyin-use-case.svg">
+            <figure id="pinyin-use-case"><img width="400" height="168" alt="羅馬拼音行間注的排版示例" src="images/zh/pinyin-use-case.svg">
               <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for Romanization.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">罗马拼音行间注的排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">羅馬拼音行間注的排版示例。</span></figcaption>
             </figure>
           </li>
@@ -2376,7 +2376,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Bilingual annotations aim to provide a Chinese translation of text in foreign languages or acronyms, or to offer the original text for words that have been translated into Chinese. This is mainly used for proper nouns, titles or those terms whose concepts are difficult to convey after translation. It is commonly found in translated works, mainly in light novels.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">为外来语、首字母缩略词标注其中译，或对翻译名词标注其原文，多见于专有名词、作品名及译后概念较难传达的词汇。常见于译作，尤以轻小说为主。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">為外來語、首字母縮略詞標注其中譯，或對翻譯名詞標注其原文，多見於專有名詞、作品名及譯後概念較難傳達的詞彙。常見於譯作，尤以輕小說為主。</p>
-            <figure id="billingual-annotation-use-case"><img width="400" alt="中外文對照行間注的排版示例" src="images/zh/billingual-annotation.svg">
+            <figure id="billingual-annotation-use-case"><img width="500" height="361" alt="中外文對照行間注的排版示例" src="images/zh/billingual-annotation.svg">
               <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for billingual annotations.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中外文对照行间注的排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">中外文對照行間注的排版示例。</span></figcaption>
             </figure>
           </li>
@@ -2411,7 +2411,7 @@ var respecConfig = {
       <p its-locale-filter-list="en" lang="en">Annotating with both Romanization and Zhuyin is a practical way to indicate the reading to readers who know only one of these systems, as well as helping study of or enquiries about the other one. Normally, when Romanization and Zhuyin are both provided, the Zhuyin are placed on the right side of the Han character while Romanization is set at the bottom of the Han character in horizontal writing mode and to the left side in vertical writing mode.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">拼注音共同标注是一种可行的作法，能同时为仅熟悉单一标音系统的两种读者提供汉字标音，并作为学习、査询另一种系统拼写的有效方式。一般情况下，“拼注音共同标注”的注音符号位于汉字右侧，横排时罗马拼音位于汉字下方，直排时位于汉字左侧。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">拼注音共同標注是一種可行的作法，能同時為僅熟悉單一標音系統的二種讀者提供漢字標音，並作為學習、査詢另一種系統拼寫的有效方式。一般情況下，「拼注音共同標注」的注音符號位漢字右側，橫排時羅馬拼音位漢字下方，直排時位漢字左側。</p>
-      <figure id="phonetic-in-both"> <img width="300" alt="拼注音共同標注排版示例" src="images/zh/phonetic-in-both.png">
+      <figure id="phonetic-in-both"> <img width="300" height="123" alt="拼注音共同標注排版示例" src="images/zh/phonetic-in-both.png">
         <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for both Romanization and Zhuyin</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">拼注音共同标注排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">拼注音共同標注排版示例。</span></figcaption>
       </figure>
     </section>
@@ -2444,7 +2444,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號的比例與大小</span>
         </h5>
 
-        <figure id="zhuyin-ratio"> <img width="400" alt="注音符號行間注下，基字與注文的比例" src="images/zh/zhuyin-rt.svg">
+        <figure id="zhuyin-ratio"> <img width="400" height="310" alt="注音符號行間注下，基字與注文的比例" src="images/zh/zhuyin-rt.svg">
           <figcaption><span its-locale-filter-list="en" lang="en">The ratios of base characters and their Zhuyin annotations.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号行间注下，基字与注文的比例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號行間注下，基字與注文的比例。</span></figcaption>
         </figure>
         <ol>
@@ -2504,7 +2504,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Mandarin non-neutral tones and dialectal non-checked tones, are placed outside the upper right corner of the last phonetic symbol. In vertical Zhuyin, half the space taken by a tone mark will be above the top of the adjacent phonetic character; in horizontal Zhuyin, half the space taken by a tone mark will appear to the right of the phonetic character. As seen in [[[#zhuyin-regular-tone]]].</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">平上去等调号标注在字音最后一个符号右上方。直式注音向上回返半个符号空间；横式注音向右突出半个符号空间。如[[[#zhuyin-regular-tone]]]所示。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">平上去等調號標注於字音最後一個符號右上方。直式注音向上回返半個符號空間；橫式注音向右突出半個符號空間。如[[[#zhuyin-regular-tone]]]所示。</p>
-            <figure id="zhuyin-regular-tone"> <img width="300" alt="一個注音符號及其調號（平上去聲）的排版" src="images/zh/zhuyin-1-0-1-one-symbol.svg"> <img width="300" alt="二個注音符號及其調號（平上去聲）的排版" src="images/zh/zhuyin-2-0-1-two-symbol.svg"> <img width="300" alt="三個注音符號及其調號（平上去聲）的排版" src="images/zh/zhuyin-3-0-1-three-symbol.svg">
+            <figure id="zhuyin-regular-tone"> <img width="300" height="233" alt="一個注音符號及其調號（平上去聲）的排版" src="images/zh/zhuyin-1-0-1-one-symbol.svg"> <img width="300" height="233" alt="二個注音符號及其調號（平上去聲）的排版" src="images/zh/zhuyin-2-0-1-two-symbol.svg"> <img width="300" height="233" alt="三個注音符號及其調號（平上去聲）的排版" src="images/zh/zhuyin-3-0-1-three-symbol.svg">
               <figcaption><span its-locale-filter-list="en" lang="en">The positioning for Zhuyin in Mandarin non-neutral tones and dialectal non-checked tones.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">各种注音符号组合及其调号（平上去声）的排版。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">各種注音符號組合及其調號（平上去聲）的排版。</span></figcaption>
             </figure>
           </li>
@@ -2512,7 +2512,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">The dialectal checked tones are set outside the lower right corner of the phonetic symbols. As seen in [[[#zhuyin-checked-tone]]].</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">入声调号标注在字音整体外侧右下方，如[[[#zhuyin-checked-tone]]]所示。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">入聲調號標注於字音整體外側右下方，如[[[#zhuyin-checked-tone]]]所示。</p>
-            <figure id="zhuyin-checked-tone"> <img width="300" alt="一個注音符號及其調號（入聲）的排版" src="images/zh/zhuyin-1-0-2-one-symbol-checked-tone.svg"> <img width="300" alt="二個注音符號及其調號（入聲）的排版" src="images/zh/zhuyin-2-0-2-two-symbol-checked-tone.svg"> <img width="300" alt="三個注音符號及其調號（入聲）的排版" src="images/zh/zhuyin-3-0-2-three-symbol-checked-tone.svg">
+            <figure id="zhuyin-checked-tone"> <img width="300" height="233" alt="一個注音符號及其調號（入聲）的排版" src="images/zh/zhuyin-1-0-2-one-symbol-checked-tone.svg"> <img width="300" height="233" alt="二個注音符號及其調號（入聲）的排版" src="images/zh/zhuyin-2-0-2-two-symbol-checked-tone.svg"> <img width="300" height="233" alt="三個注音符號及其調號（入聲）的排版" src="images/zh/zhuyin-3-0-2-three-symbol-checked-tone.svg">
               <figcaption><span its-locale-filter-list="en" lang="en">The positioning for Zhuyin in dialectal checked tones.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">各种注音符号组合及其调号（入声）的排版。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">各種注音符號組合及其調號（入聲）的排版。</span></figcaption>
             </figure>
           </li>
@@ -2537,10 +2537,10 @@ var respecConfig = {
         <ol>
           <li id="id132">
             <figure>
-              <img width="200" alt="「安」字的國語注音符號拼式" src="images/zh/zhuyin-1-1-one-symbol-an1.svg">
-              <img width="200" alt="「哦」字的國語注音符號拼式" src="images/zh/zhuyin-1-2-one-symbol-o2.svg">
-              <img width="200" alt="「壹」字的閩南語注音符號拼式" src="images/zh/zhuyin-1-3-one-symbol-it.svg">
-              <img width="200" alt="「啊」字的國語注音符號拼式" src="images/zh/zhuyin-1-4-one-symbol-a.svg">
+              <img width="200" height="168" alt="「安」字的國語注音符號拼式" src="images/zh/zhuyin-1-1-one-symbol-an1.svg">
+              <img width="200" height="168" alt="「哦」字的國語注音符號拼式" src="images/zh/zhuyin-1-2-one-symbol-o2.svg">
+              <img width="200" height="168" alt="「壹」字的閩南語注音符號拼式" src="images/zh/zhuyin-1-3-one-symbol-it.svg">
+              <img width="200" height="168" alt="「啊」字的國語注音符號拼式" src="images/zh/zhuyin-1-4-one-symbol-a.svg">
               <figcaption>
                 <span its-locale-filter-list="en" lang="en">Examples of annotations with a single Zhuyin phonetic symbol and how they cooperate with different kinds of tones.</span>
                 <span its-locale-filter-list="zh-hans" lang="zh-hans">单个注音符号构成的拼式及其搭配各种声调的示例。</span>
@@ -2550,10 +2550,10 @@ var respecConfig = {
           </li>
           <li id="id133">
             <figure>
-              <img width="200" alt="「西」字的國語注音符號拼式" src="images/zh/zhuyin-2-1-two-symbol-xi1.svg">
-              <img width="200" alt="「我」字的國語注音符號拼式" src="images/zh/zhuyin-2-2-two-symbol-wo3.svg">
-              <img width="200" alt="「力」字的閩南語注音符號拼式" src="images/zh/zhuyin-2-3-two-symbol-lik.svg">
-              <img width="200" alt="「了」字的國語注音符號拼式" src="images/zh/zhuyin-2-4-two-symbol-le.svg">
+              <img width="200" height="168" alt="「西」字的國語注音符號拼式" src="images/zh/zhuyin-2-1-two-symbol-xi1.svg">
+              <img width="200" height="168" alt="「我」字的國語注音符號拼式" src="images/zh/zhuyin-2-2-two-symbol-wo3.svg">
+              <img width="200" height="168" alt="「力」字的閩南語注音符號拼式" src="images/zh/zhuyin-2-3-two-symbol-lik.svg">
+              <img width="200" height="168" alt="「了」字的國語注音符號拼式" src="images/zh/zhuyin-2-4-two-symbol-le.svg">
               <figcaption>
                 <span its-locale-filter-list="en" lang="en">Examples of annotations with two Zhuyin phonetic symbols and how they cooperate with different kinds of tones.</span>
                 <span its-locale-filter-list="zh-hans" lang="zh-hans">两个注音符号构成的拼式及其搭配各种声调的示例。</span>
@@ -2563,10 +2563,10 @@ var respecConfig = {
           </li>
           <li id="id134">
             <figure>
-              <img width="200" alt="「心」字的國語注音符號拼式" src="images/zh/zhuyin-3-1-three-symbol-xin1.svg">
-              <img width="200" alt="「嘴」字的國語注音符號拼式" src="images/zh/zhuyin-3-2-three-symbol-zui3.svg">
-              <img width="200" alt="「著」字的閩南語注音符號拼式" src="images/zh/zhuyin-3-3-three-symbol-tioh.svg">
-              <img width="200" alt="「作」字的國語注音符號拼式" src="images/zh/zhuyin-3-4-three-symbol-zuo.svg">
+              <img width="200" height="168" alt="「心」字的國語注音符號拼式" src="images/zh/zhuyin-3-1-three-symbol-xin1.svg">
+              <img width="200" height="168" alt="「嘴」字的國語注音符號拼式" src="images/zh/zhuyin-3-2-three-symbol-zui3.svg">
+              <img width="200" height="168" alt="「著」字的閩南語注音符號拼式" src="images/zh/zhuyin-3-3-three-symbol-tioh.svg">
+              <img width="200" height="168" alt="「作」字的國語注音符號拼式" src="images/zh/zhuyin-3-4-three-symbol-zuo.svg">
               <figcaption>
                 <span its-locale-filter-list="en" lang="en">Examples of annotations with three Zhuyin phonetic symbols and how they cooperate with different kinds of tones.</span>
                 <span its-locale-filter-list="zh-hans" lang="zh-hans">三个注音符号构成的拼式及其搭配各种声调的示例。</span>
@@ -2722,7 +2722,7 @@ var respecConfig = {
           </li>
         </ol>
 
-        <figure id="group-ruby"> <img width="400" alt="分詞連寫標音示例" src="images/zh/group-ruby.png">
+        <figure id="group-ruby"> <img width="500" height="155" alt="分詞連寫標音示例" src="images/zh/group-ruby.png">
           <figcaption><span its-locale-filter-list="en" lang="en">An example of words as the basic units for annotating pronunciation.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">分词连写标音的排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">分詞連寫標音的排版示例。</span></figcaption>
         </figure>
       </section>
@@ -2748,7 +2748,7 @@ var respecConfig = {
         <p its-locale-filter-list="en" lang="en">Erhuayin, also known as rhotacization of syllable finals, is a special phonetic phenomenon in Modern Standard Chinese (Mandarin). Due to the limitations of annotating single Han characters, the Zhuyin annotations fail to indicate the continuity of Erhuayin and the change of the final sound, while Romanization shows the features of Erhuayin effectively.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">对现代标准汉语的特殊语音现象——儿化，注音符号受制于其标注单个汉字的局限，难以准确表达儿化音节的连续性及韵母变音，需要在正文或附注中额外说明；罗马拼音则可有效标注此现象。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">對現代標準漢語的特殊語音現象——兒化，注音符號受制於其標注單個漢字的局限，難以準確表達兒化音節的連續性及韻母變音，需要在正文或附注中額外說明；羅馬拼音則可有效標注此現象。</p>
-        <figure id="phonetic-annotation-erhua"> <img width="300" alt="兒化音的排版示例" src="images/zh/biaoyin-erhua.svg">
+        <figure id="phonetic-annotation-erhua"> <img width="500" height="195" alt="兒化音的排版示例" src="images/zh/biaoyin-erhua.svg">
           <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for Zhuyin in Mandarin rhotacization of syllable finals.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">儿化音的排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">兒化音的排版示例。</span></figcaption>
         </figure>
       </section>


### PR DESCRIPTION
Add explicit width and height on images to reduce layout shifts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/469.html" title="Last updated on Jun 8, 2022, 6:03 AM UTC (2f98f2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/469/8f06e52...2f98f2b.html" title="Last updated on Jun 8, 2022, 6:03 AM UTC (2f98f2b)">Diff</a>