### PR TITLE
Add search function to the Glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -4700,7 +4700,12 @@ var respecConfig = {
     <span its-locale-filter-list="zh-hant" lang="zh-hant">詞彙表</span>
   </h2>
 
-  <table class="appendix glossary">
+  <div class="input">
+    <!-- <label for="search">Search:</label> -->
+    <input placeholder="Search" type="text" id="search">
+</div>
+
+  <table class="appendix glossary" id="filter">
     <thead>
       <tr>
         <th class="term">
@@ -5673,6 +5678,27 @@ var respecConfig = {
   <p its-locale-filter-list="zh-hans" lang="zh-hans">欲了解最新的参与者信息，请参看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub贡献者列表</a>。</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">欲了解最新的參與者信息，請參看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub貢獻者列表</a>。</p>
 </section>
+
+<script>
+  const search = document.getElementById('search')
+  const table = document.getElementById('filter')
+  const trArray = Array.prototype.slice.call(table.querySelectorAll('tbody tr'))
+
+  const filter = event => {
+    const searchTerm = event.target.value.toLowerCase()
+    trArray.forEach(row => {
+      row.classList.add('hidden')
+      const tdArray = Array.prototype.slice.call(row.getElementsByTagName('td'))
+      tdArray.forEach(cell => {
+        if (cell.innerText.toLowerCase().indexOf(searchTerm) > -1) {
+          row.classList.remove('hidden')
+        }
+      })
+    })
+  }
+
+  search.addEventListener('keyup', filter, false)
+</script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4703,7 +4703,7 @@ var respecConfig = {
   <div class="input">
     <!-- <label for="search">Search:</label> -->
     <input placeholder="Search" type="text" id="search">
-</div>
+  </div>
 
   <table class="appendix glossary" id="filter">
     <thead>

--- a/local.css
+++ b/local.css
@@ -301,3 +301,39 @@ table.glossary th.term-en { width: 5.25em; }
 
 /* Override the display property */
 [its-locale-filter-list][hidden] { display: none; }
+
+/* Search */
+.input {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  letter-spacing: normal;
+  max-width: 100%;
+  text-align: left;
+  padding: 16px;
+  margin-top: 4px;
+  transition: .3s cubic-bezier(.25, .8, .5, 1);
+}
+
+/* label {
+  margin-right: 15px;
+} */
+
+#search {
+  color: rgba(0, 0, 0, .87);
+  max-height: 32px;
+  flex: 1 1 auto;
+  line-height: 20px;
+  padding: 8px 0;
+  max-width: 100%;
+  min-width: 0;
+  width: 100%;
+  background-color: transparent;
+  border-style: none;
+  border-radius: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, .42);
+}
+
+.hidden {
+  display: none;
+}

--- a/local.css
+++ b/local.css
@@ -312,7 +312,6 @@ table.glossary th.term-en { width: 5.25em; }
   text-align: left;
   padding: 16px;
   margin-top: 4px;
-  transition: .3s cubic-bezier(.25, .8, .5, 1);
 }
 
 /* label {


### PR DESCRIPTION
This PR adds a simple search bar above the glossary table (without [debounce](https://medium.com/nerd-for-tech/debounce-your-search-react-input-optimization-fd270a8042b)). Do you find this useful?

If you have ideas for a better UI, please feel free to suggest them (preferably with the corresponding CSS code)!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/478.html" title="Last updated on Jul 21, 2022, 1:34 PM UTC (59693f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/478/91f9a12...59693f7.html" title="Last updated on Jul 21, 2022, 1:34 PM UTC (59693f7)">Diff</a>