### PR TITLE
Fix #496

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@ var respecConfig = {
         <p its-locale-filter-list="zh-hant" lang="zh-hant">中文的書寫方向有直排及橫排二種，其中，前者多見於台灣、香港等地的中文出版品。</p>
       </li>
       <li id="id5">
-        <p its-locale-filter-list="en" lang="en"> In principal, the characters, including Chinese (hanzi) characters and punctuation, used in Chinese composition are squares with the ratio of 1:1, and are seamlessly arranged with one another.</p>
+        <p its-locale-filter-list="en" lang="en"> In principal, the characters, including Han characters (Hanzi) and punctuation, used in Chinese composition are squares with the ratio of 1:1, and are seamlessly arranged with one another.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">原则上，中文排版所使用的汉字和标点符号比例皆为1:1的正方形，将其无缝隙并列排成版面。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">原則上，中文排版所使用的漢字與標點符號比例皆為1:1的正方形，將其無縫隙並列排成版面。</p>
       </li>
@@ -306,13 +306,13 @@ var respecConfig = {
       <p its-locale-filter-list="en" lang="en">The majority of the text used in Chinese composition consists of Han characters (Hanzi).</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版主要使用的文字为汉字。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版主要使用的文字為漢字。</p>
-      <p its-locale-filter-list="en" lang="en">Chinese characters include Traditional Chinese and Simplified Chinese alternatives. The former is commonly used in Taiwan, Hong Kong and Macao while the latter is commonly used in Mainland China, Singapore and Malaysia.</p>
+      <p its-locale-filter-list="en" lang="en" class="checkme">Chinese characters include Traditional Chinese and Simplified Chinese alternatives. The former is commonly used in Taiwan, Hong Kong and Macao while the latter is commonly used in Mainland China, Singapore and Malaysia.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">依照各地的通行标准，中文所使用的汉字主要分为繁体字与简体字。前者又称正体字、传统汉字等，主要通行于台湾、香港、澳门等地；后者又作简化字，主要通行于中国大陆、新马地区。本文依笔画多寡与部件结构为区别，分别称为繁体字与简体字。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">依照各地的通行標準，中文所使用的漢字主要分為繁體字與簡體字。前者又作正體字、傳統漢字等，主要通行於台灣、香港、澳門等地；後者又作簡化字，主要通行於中國大陸、星馬地區。本文依筆畫多寡與部件結構為區別，分別稱為繁體字與簡體字。</p>
-      <p its-locale-filter-list="en" lang="en">Different glyphs are used in different regions. One <a href="https://www.w3.org/TR/i18n-glossary/#def_unicode_code_point">Unicode code point</a> of a Chinese character may have more than one valid glyph, depending on operating system and typeface used. The focus of this document is Chinese composition and will not cover glyph variations in detail.</p>
+      <p its-locale-filter-list="en" lang="en">Different glyphs are used in different regions. One <a href="https://www.w3.org/TR/i18n-glossary/#def_unicode_code_point">Unicode code point</a> of a Han character may have more than one valid glyph, depending on operating system and typeface used. The focus of this document is Chinese composition and will not cover glyph variations in detail.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">不同地区所使用的字形有差异，各种字形与<a href="https://www.w3.org/TR/i18n-glossary/#def_unicode_code_point">Unicode码位</a>并非一一对应关系，需要依赖处理系统和字体来呈现。本文主要探究中文排版，对此不做详述。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">不同地區所使用的字形有差異，各種字形與<a href="https://www.w3.org/TR/i18n-glossary/#def_unicode_code_point">Unicode碼位</a>並非一一對應關係，需要依賴處理系統和字體來呈現。本文主要探究中文排版，對此不做詳述。</p>
-      <p its-locale-filter-list="en" lang="en">In addition to Chinese characters (Hanzi), various punctuation marks, as well as Western characters such as European numerals, Latin letters and/or Greek letters, may be used in Chinese text. </p>
+      <p its-locale-filter-list="en" lang="en">In addition to Han characters (Hanzi), various punctuation marks, as well as Western characters such as European numerals, Latin letters and/or Greek letters, may be used in Chinese text. </p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版除了汉字外，也使用标点符号，也会与阿拉伯数字、拉丁文字、希腊文字等外文混排。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版除了漢字外，也使用標點符號。也會與阿拉伯數字、拉丁文字、希臘文字等外文混排。</p>
 
@@ -326,12 +326,12 @@ var respecConfig = {
 
     <section id="han_characters">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Chinese Characters</span>
+        <span its-locale-filter-list="en" lang="en">Han Characters</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">汉字</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">漢字</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">Chinese characters have square <a href="#term.character-frame" class="termref">character frames</a> of equal dimensions. Aligned with the vertical and horizontal center of the character frame, there is a smaller box called the <a href="#term.character-face" class="termref">character face</a>, which contains the actual symbol. (There should be some space left between the character face and the character frame).</p>
+      <p its-locale-filter-list="en" lang="en">Han characters have square <a href="#term.character-frame" class="termref">character frames</a> of equal dimensions. Aligned with the vertical and horizontal center of the character frame, there is a smaller box called the <a href="#term.character-face" class="termref">character face</a>, which contains the actual symbol. (There should be some space left between the character face and the character frame).</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字有着正方形的<a href="#term.character-frame" class="termref">文字外框</a>。文字外框的正中央，有着比文字外框小的<a href="#term.character-face" class="termref">字面</a>（反过来说，字面的上下左右与文字外框之间有若干空白。根据不同的字面设计，空白的大小会有所不同）。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字有著正方形的<a href="#term.character-frame" class="termref">文字外框</a>。文字外框的正中央，有著比文字外框小的<a href="#term.character-face" class="termref">字面</a>（反過來說，字面的上下左右與文字外框之間有若干空白。根據不同的字面設計，空白的大小會有所不同）。</p>
       <p its-locale-filter-list="en" lang="en">Character size is measured by the size of the character frame. <dfn id="def_characterAdvance">Character advance</dfn> is a term used to describe the advance width of the character frame of a character, which should be the same as the width of the character.</p>
@@ -347,7 +347,7 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hant" lang="zh-hant">漢字的配置原則</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">In principle, when composing a line with Chinese characters, no extra space appears between their character frames. This is called <a href="#term.solid-setting" class="termref">solid setting</a>. </p>
+      <p its-locale-filter-list="en" lang="en">In principle, when composing a line with Han characters, no extra space appears between their character frames. This is called <a href="#term.solid-setting" class="termref">solid setting</a>. </p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字依行排列文字，原则上文字外框彼此紧贴配置，称作<a href="#term.solid-setting" class="termref">密排</a>。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字依行排列文字，原則上文字外框彼此緊貼配置，稱作<a href="#term.solid-setting" class="termref">密排</a>。</p>
       <div class="note" id="n003">
@@ -409,7 +409,7 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hant" lang="zh-hant">均排</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en">Text may be set with equal inter-character spacing between all characters on a given line, so that each line is aligned to the same line head and line end. Since the Chinese characters and punctuation marks are all in square frames with almost the same dimensions, it is natural that each line is aligned to the same line head and line end. Even inter-character spacing is mainly used in the following cases:</p>
+        <p its-locale-filter-list="en" lang="en">Text may be set with equal inter-character spacing between all characters on a given line, so that each line is aligned to the same line head and line end. Since the Han characters and punctuation marks are all in square frames with almost the same dimensions, it is natural that each line is aligned to the same line head and line end. Even inter-character spacing is mainly used in the following cases:</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">平均分配字距，使文字两端能够对齐行首与行尾。中文排版时，由于使用的汉字与标点符号皆为正方形，自然会使得文字列对齐行首与行尾。这种排列方式主要应用于以下情况：</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">平均分配字距，使文字兩端能夠對齊行首與行尾。中文排版時，由於使用的漢字與標點符號皆為正方形，自然會使得文字列對齊行首與行尾。這種排列方式主要應用於以下情況：</p>
         <ol>
@@ -453,7 +453,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hant" lang="zh-hant">雜誌標題及廣告文案字數較多，為使其排列於一行，或為求特殊表現時使用。</p>
           </li>
           <li id="id21">
-            <p its-locale-filter-list="en" lang="en">Since Chinese characters are all square-shaped, this method does not apply to headings and content in books produced by letterpress printing.</p>
+            <p its-locale-filter-list="en" lang="en">Since Han characters are all square-shaped, this method does not apply to headings and content in books produced by letterpress printing.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字皆为正方形，此方式并不适用于活字排版，故不应用于书籍标题与内文的排列上。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字皆為正方形，此方式並不適用於活字排版，故不應用於書籍標題與內文的排列上。</p>
           </li>
@@ -469,14 +469,14 @@ var respecConfig = {
 
   <section id="commonly_used_chinese_typefaces">
     <h3>
-      <span its-locale-filter-list="en" lang="en">Typefaces for Chinese Characters</span>
+      <span its-locale-filter-list="en" lang="en">Typefaces for Chinese Text</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版常用字体</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版常用字體</span>
     </h3>
 
     <section id="four_commonly_used_typefaces_for_chinese_composition">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Four frequently-used Typefaces for Chinese Characters</span>
+        <span its-locale-filter-list="en" lang="en">Four frequently-used Typefaces for Chinese Text</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版经常使用的四种字体</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版經常使用的四種字體</span>
       </h4>
@@ -541,7 +541,7 @@ var respecConfig = {
         </figcaption>
       </figure>
 
-      <p its-locale-filter-list="en" lang="en"><dfn id="endef_kai" class="lint-ignore">Kai</dfn> also known as Kaiti or regular script, is another major typeface, which provides calligraphic styles for Chinese characters. It shows notable handwriting features. As seen in [[[#fig-kai]]].</p>
+      <p its-locale-filter-list="en" lang="en"><dfn id="endef_kai" class="lint-ignore">Kai</dfn> also known as Kaiti or regular script, is another major typeface, which provides calligraphic styles for Chinese text. It shows notable handwriting features. As seen in [[[#fig-kai]]].</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">楷体又称正书、真书，为中文排版常用的字体。字体特性为带有书法形态、手写笔触。如[[[#fig-kai]]]所示。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">楷體又稱正書、真書，為中文排版常用的字體。字體特性為帶有書法形態、手寫筆觸。如[[[#fig-kai]]]所示。</p>
 
@@ -698,7 +698,7 @@ var respecConfig = {
         </li>
       </ul>
       <div class="note" id="n005">
-        <p its-locale-filter-list="en" lang="en" class="checkme">Establishing a type area may be seen as defining not only a rectangular area on a page, but also within that area, an underlying, logical grid to guide the placement of such things as characters, headings, and illustrations. Once the grid is established according to the principles of composition, the setting of the characters must align with the grid. If the content contains Chinese characters only, it is important that the first and last characters on a line should align with the border of the type area. When both Chinese characters and Western text are mixed in the content, or forbidden locations of punctuation marks need to be taken into consideration, the setting of the content may not align with the grid.</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">Establishing a type area may be seen as defining not only a rectangular area on a page, but also within that area, an underlying, logical grid to guide the placement of such things as characters, headings, and illustrations. Once the grid is established according to the principles of composition, the setting of the characters must align with the grid. If the content contains Chinese text only, it is important that the first and last characters on a line should align with the border of the type area. When both Chinese text and Western text are mixed in the content, or forbidden locations of punctuation marks need to be taken into consideration, the setting of the content may not align with the grid.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式设定步骤不仅是在页面中设定一个长方形空间，还需要为内文、标题、图片配置等做出一个基础的格子设定。其格子设定于中文排版原则下，内文必须依照格子进行配置。在文章仅由汉字构成的状况下，行首、行尾对齐版心边界是中文书排版重要的原则。但在与西文混排、或配置标点禁则处理时，为遵从本项原则，内文可不按照格子排列。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式設定步驟不僅是在頁面中設定一個長方形空間，還需要為內文、標題、圖片配置等做出一個基礎的格子設定。其格子設定於中文排版原則下，內文必須依照格子進行配置。在文章僅由漢字構成的狀況下，行首、行尾對齊版心邊界是中文書排版重要的原則。但在與西文混排、或配置標點禁則處理時，為遵從本項原則，內文可不按照格子排列。</p>
       </div>
@@ -863,7 +863,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">決定版心尺寸時，須先考量到完成尺寸與留白後進行。一般而言，版心與完成尺寸會呈相似形的設計。</p>
         </li>
         <li id="id51">
-          <p its-locale-filter-list="en" lang="en">There have been different size systems for Chinese characters. The size system in traditional metal type utilized hào (literally number) units, while in the phototypesetting era, Q was used as the sizing unit instead. When it came to desktop publishing, font sizes were determined by the DTP point system which was built into the software itself. Currently, the traditional hào-system is still used for typesetting in many Chinese publications.</p>
+          <p its-locale-filter-list="en" lang="en" class="checkme">There have been different size systems for Chinese fonts. The size system in traditional metal type utilized hào (literally number) units, while in the phototypesetting era, Q was used as the sizing unit instead. When it came to desktop publishing, font sizes were determined by the DTP point system which was built into the software itself. Currently, the traditional hào-system is still used for typesetting in many Chinese publications.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">中文活字大小有不同单位。在金属活字时代，传统中文活字尺寸以“号”为单位，故称作“字号”；在照相排版时代沿用照排机尺寸的单位“级”，故称作“字级”；在桌面排版时代，直接使用桌面排版软件中的“点”（DTP point）。目前，很多场合的中文排版依旧习惯沿用“号”。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">中文活字大小有不同單位。在金屬活字時代，傳統中文活字尺寸以「號」為單位，故稱作「字號」；在照相排版時代沿用照排機尺寸的單位「級」，故稱作「字級」；在桌面排版時代，直接使用桌面排版軟件中的「點」（DTP point）。目前，很多場合的中文排版依舊習慣沿用「號」。</p>
 
@@ -1048,7 +1048,7 @@ var respecConfig = {
             </tbody>
           </table>
 
-          <p its-locale-filter-list="en" lang="en">Size 5 is usually used for body text. Newspapers and magazines use both Size 5 and New Size 5. The acceptable minimum size for the text in content is Size 6  (7.875&nbsp;pt ≒ 2.8&nbsp;mm). If a smaller size is used, it will be difficult to read due to the complex structure of Chinese characters.</p>
+          <p its-locale-filter-list="en" lang="en">Size 5 is usually used for body text. Newspapers and magazines use both Size 5 and New Size 5. The acceptable minimum size for the text in content is Size 6  (7.875&nbsp;pt ≒ 2.8&nbsp;mm). If a smaller size is used, it will be difficult to read due to the complex structure of Han characters.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">一般内文主要使用五号字（10.5&nbsp;pt ≒ 3.7&nbsp;mm），而报纸、杂志则使用新五号字（9&nbsp;pt ≒ 3.2&nbsp;mm），两种皆常用。而一般内文字最小使用到六号字（7.875&nbsp;pt ≒ 2.8&nbsp;mm），若小于此尺寸，由于汉字结构复杂，较难阅读。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">一般內文主要使用五號字（10.5&nbsp;pt ≒ 3.7&nbsp;mm），而報紙、雜誌則使用新五號字（9&nbsp;pt ≒ 3.2&nbsp;mm），兩種皆常用。而一般內文字最小使用到六號字（7.875&nbsp;pt ≒ 2.8&nbsp;mm），若小於此尺寸，由於漢字結構複雜，較難閱讀。</p>
         </li>
@@ -1208,7 +1208,7 @@ var respecConfig = {
               <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時，西文或<a href="#term.european-numerals" class="termref">阿拉伯數字</a>有以下三種配置方式：</p>
               <ul>
                 <li id="id67">
-                  <p its-locale-filter-list="en" lang="en">One by one, with the same normal orientation as Chinese characters. This is usually applied to one-letter alphanumerics or acronyms.</p>
+                  <p its-locale-filter-list="en" lang="en">One by one, with the same normal orientation as Han characters. This is usually applied to one-letter alphanumerics or acronyms.</p>
                   <p its-locale-filter-list="zh-hans" lang="zh-hans">与汉字采相同的书写方向，依字母逐个排列，主要用于单一西文字母或阿拉伯数字、首字母缩写等。</p>
                   <p its-locale-filter-list="zh-hant" lang="zh-hant">與漢字採相同的書寫方向，依字母逐個排列，主要用於單一西文字母或阿拉伯數字、首字母縮寫等。</p>
                   <figure id="latin-one-by-one">
@@ -1222,7 +1222,7 @@ var respecConfig = {
                       </figcaption>
                   </figure>
                   <div class="note" id="n017">
-                    <p its-locale-filter-list="en" lang="en">Western text or <a href="#term.european-numerals" class="termref">European numerals</a> used for this arrangement should have the same fixed size and width as the Chinese characters, rather than a proportional width.</p>
+                    <p its-locale-filter-list="en" lang="en">Western text or <a href="#term.european-numerals" class="termref">European numerals</a> used for this arrangement should have the same fixed size and width as the Han characters, rather than a proportional width.</p>
                     <p its-locale-filter-list="zh-hans" lang="zh-hans">西文字母或<a href="#term.european-numerals" class="termref">阿拉伯数字</a>，采用此配置时，需使用与汉字相同尺寸、字幅固定的等宽字体，而非比例字体。</p>
                     <p its-locale-filter-list="zh-hant" lang="zh-hant">西文字母或<a href="#term.european-numerals" class="termref">阿拉伯數字</a>，採用此配置時，需使用與漢字相同尺寸、字幅固定的等寬字體，而非比例字體。</p>
                   </div>
@@ -1652,7 +1652,7 @@ var respecConfig = {
       <p its-locale-filter-list="en" lang="en">Ellipses and two-em dashes, should be vertically and horizontally centered within their square frame, and should be one character in height and two characters in width. They are not supposed to be separated from one line to the next and should be positioned in the same direction as the characters.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">省略号、破折号等标号，位字面正中，占两个汉字的空间，并不得以适配分行之由断开或拆至两行，依文字书写方向使用相应的标注方向。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">刪節號、破折號等標號，位字面正中，佔兩個漢字的空間，並不得以適配分行之由斷開或拆至兩行，依文字書寫方向使用相應的標注方向。</p>
-      <p its-locale-filter-list="en" lang="en">Connector marks should take up the same dimensions as a single character, and be vertically and horizontally centered within its square frame. Among the connector marks, the EN DASH should have a short length to distinguish it from the Chinese character [一], which means one. And they should be positioned in the same direction as the characters they mark.</p>
+      <p its-locale-filter-list="en" lang="en">Connector marks should take up the same dimensions as a single character, and be vertically and horizontally centered within its square frame. Among the connector marks, the EN DASH should have a short length to distinguish it from the Han character [一], which means one. And they should be positioned in the same direction as the characters they mark.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">连接号位于字面正中，占一个汉字的大小，其中，甲式连接号在横排时，符号的直线长度应稍小于汉字“一”以避免歧义，按照文字书写方向使用相应的标注方向。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">連接號位字面正中，佔一個漢字的大小，其中，甲式連接號在橫排時，符號的直線長度應稍小於漢字「一」以避免歧義，依文字書寫方向使用相應的標注方向。</p>
       <p its-locale-filter-list="en" lang="en" class="checkme">Middle dots should be vertically and horizontally centered within their square frame. To make more economical use of the available space, or to tighten the overall spacing, sometimes the solidus can have 1/2&nbsp;em.</p>
@@ -2325,7 +2325,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.interlinear-annotations" class="termref">行間注</a>是標注於字詞旁側的小字號補充文本。行間注的注文通常位於行間，與其所標注的基文對齊，因這一性質而又名為行間注。行間注在中文排版里的用途主要為標音與釋義。</p>
       <section id="h-indicating_pronunciation_for_chinese_characters">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Indicating the Pronunciation for Chinese characters</span>
+          <span its-locale-filter-list="en" lang="en">Indicating the Pronunciation for Han characters</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">为汉字标注读音</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">為漢字標注讀音</span>
         </h5>
@@ -2354,7 +2354,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en" class="leadin">Romanization.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="leadin checkme">罗马拼音</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="leadin">羅馬拼音</p>
-            <p its-locale-filter-list="en" lang="en">Hanyu Pinyin (汉语拼音), now the official standard in Mainland China, uses the Latin alphabet to transcribe the Modern Standard Chinese (Mandarin) pronunciations of Chinese characters. The most common use case in Mainland China is to indicate the pronunciation for all characters of the full text with Hanyu Pinyin. In Taiwan and areas that use Chinese dialects in China, the arrangement of the Taiwanese Romanization System for Minnan (<span lang="zh-hant">台灣閩南語羅馬字</span>), or romanization systems of other Chinese dialects are similar to those of Hanyu Pinyin.</p>
+            <p its-locale-filter-list="en" lang="en">Hanyu Pinyin (汉语拼音), now the official standard in Mainland China, uses the Latin alphabet to transcribe the Modern Standard Chinese (Mandarin) pronunciations of Han characters. The most common use case in Mainland China is to indicate the pronunciation for all characters of the full text with Hanyu Pinyin. In Taiwan and areas that use Chinese dialects in China, the arrangement of the Taiwanese Romanization System for Minnan (<span lang="zh-hant">台灣閩南語羅馬字</span>), or romanization systems of other Chinese dialects are similar to those of Hanyu Pinyin.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用拉丁字母的汉语拼音是中国大陆推行的现代标准汉语（普通话）标音与拉丁转写方案，汉语拼音的全文标音也是中国大陆现代最常见的行间注用例。在中国大陆与台湾，台湾闽南语罗马字拼音等各种汉语方言的拉丁字母标音方案也有与汉语拼音情况类似的行间注用例。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">使用拉丁字母的漢語拼音是中國大陸推行的現代標準漢語（普通話）標音與拉丁轉寫方案，漢語拼音的全文標音也是中國大陸現代最常見的行間注用例。在台灣與中國大陸漢語方言使用地區，台灣閩南語羅馬字拼音等各種漢語方言的拉丁字母標音方案也有與漢語拼音情況類似的行間注用例。</p>
             <p its-locale-filter-list="en" lang="en">Due to the characteristics of the Latin alphabet, such annotations appear in horizontal writing mode only. Texts for children who are native speakers usually provide reading assistance for each individual character, while texts for those who are learning Chinese as a second language mainly indicate pronunciation for whole words, but occasionally, both of them are set almost the same. There is space between the base text when whole words are annotated, and the interlinear annotation characters will have unique requirements such as sentence case, or punctuation marks corresponding to base characters. The composition of early publications using pinyin was quite variable and not consistent. In general, both character-based and word-based annotations were quite common. No further description of the early pinyin will be found in this document.</p>
@@ -4836,7 +4836,7 @@ var respecConfig = {
         <td>biāoyīn</td>
         <td>phonetic annotation</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">The way to indicate the pronunciation of the Chinese characters, e.g. interlinear annotations.</p>
+          <p its-locale-filter-list="en" lang="en">The way to indicate the pronunciation of the Han characters, e.g. interlinear annotations.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">为汉字标注发音的方式，主要有行间注等。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為漢字標注發音的方式，主要有行間注等。</p>
         </td>


### PR DESCRIPTION
This revision is based on the issue #496 and the discussion on the [editors’ call on 18 Oct 2022](https://www.w3.org/2022/10/18-clreq-minutes.html#t06).

* Unify the terms of “Chinese character(s)” and “Han character(s)”.
* Replace some misused “Chinese character(s)” with “Chinese text”.
* Replace a misused “Chinese characters” with “Chinese fonts”.
* Mark some uncertain paragraphs with `checkme`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/504.html" title="Last updated on Nov 6, 2022, 2:22 PM UTC (c389a35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/504/8ccc302...realfish:c389a35.html" title="Last updated on Nov 6, 2022, 2:22 PM UTC (c389a35)">Diff</a>