### PR TITLE
Update the charter

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -132,7 +132,7 @@
 
 <section id="scope" class="scope">
 <h2>Scope</h2>
-<p>The proposal for the group originated from consultation with stakeholders and W3C members in China on how to help facilitate increased involvement in W3C activities around CSS, digital-publishing, and other Web technologies for the languages of China.</p>
+<p>The proposal for the group originated from consultation with stakeholders and W3C members in China on how to help facilitate increased involvement in W3C activities around CSS, digital-publishing, and other Web technologies for Simplified and Traditional Chinese.</p>
 <p>In addition to those specifications, the group may review (but is by no means explicitly limited to reviewing) the following:
 
 </p>
@@ -153,6 +153,7 @@
 <li>Browser testing and Tools</li>
 <li>HTML (in particular references to ruby, locale-specific formats, and other internationalization aspects)</li>
 <li>EPUB</li>
+<li>Accessibility standards</li>
 </ul>
 
 <p>The group may also review draft specifications produced by Web API related working groups. Along with reviewing the above-mentioned specifications and related specifications, it is expected that the group will also gather comments and questions about those specifications, collect information about specific use cases in China for technologies defined in those specifications, and report the results of its activities as a group back to the Internationalization Working Group, as well as to other relevant groups - such as the CSS Working Group, SVG Working Group, WHATWG etc.</p>
@@ -205,6 +206,7 @@
         <li><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></li>
         <li><a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB 3 Working Group</a></li>
         <li><a href="https://www.w3.org/2018/chinese-web-ig/">Chinese Web Interest Group</a></li>
+        <li><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></li>
       </ul>
     </dd>
     <dt>Other Groups</dt>

--- a/charter/index.html
+++ b/charter/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang=en>
 <head>
   <meta charset="utf-8">
   <title>Chinese Text Layout Task Force Charter</title>

--- a/charter/index.html
+++ b/charter/index.html
@@ -1,14 +1,14 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+  <meta charset="utf-8">
   <title>Chinese Text Layout Task Force Charter</title>
   <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css"
-  type="text/css" media="screen" />
+  type="text/css" media="screen">
   <link rel="stylesheet" type="text/css"
-  href="https://www.w3.org/Guide/pubrules-style.css" />
+  href="https://www.w3.org/Guide/pubrules-style.css">
   <link rel="stylesheet" type="text/css"
-  href="https://www.w3.org/2006/02/charter-style.css" />
+  href="https://www.w3.org/2006/02/charter-style.css">
   <style>
       main {
         max-width: 60em;
@@ -47,7 +47,7 @@
       footer {
         font-size: small;
       }
-  
+
   ins { background-color: #FF6; }
   del { color: gray; }
   </style>
@@ -58,6 +58,7 @@
   <header id="header">
     <aside>
       <ul id="navbar">
+        <li><a href="#background">Background</a></li>
         <li><a href="#scope">Scope</a></li>
         <li><a href="#deliverables">Deliverables</a></li>
         <li><a href="#success-criteria">Success Criteria</a></li>
@@ -78,6 +79,7 @@
   <main>
 
 <h1 id="title">Chinese Text Layout Task Force Charter</h1>
+<section id="background" class="background">
 <p class="mission">The <strong>mission</strong> of this task force  is to  document gaps and requirements for support of Simplified and Traditional Chinese on the Web and in eBooks. </p>
 <p class="mission">The documents will provide requirements for the development of W3C standards affected by Simplified and Traditional Chinese. This task force will gather and integrate feedback from the participating members about the need  for and technical feasibility of various requirements.</p>
 <p class="mission">The Task Force is part of the Internationalization Interest Group.</p>
@@ -87,6 +89,7 @@
 <p class="mission">
   This charter is intended to reflect the current direction of the group, so that there is common agreement. It may be altered at any point in order to reflect new priorities or work items.
 </p>
+</section>
 <div class="noprint">
   <p class="join"><a href="https://www.chinaw3c.org/clreq-home.html#join">Join the Chinese Text Layout Task Force</a>.</p>
 </div>
@@ -96,24 +99,24 @@
   <tbody>
     <tr id="Duration">
       <th rowspan="1" colspan="1">End date</th>
-      <td rowspan="1" colspan="1">2023-04-30</td>
+      <td rowspan="1" colspan="1">2025-04-30</td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Confidentiality</th>
       <td rowspan="1" colspan="1">Proceedings are <a
-        href="https://www.w3.org/2020/Process-20200915/#confidentiality-levels"
+        href="https://www.w3.org/2021/Process-20211102/#confidentiality-levels"
        >public </a></td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Chairs</th>
-      <td rowspan="1" colspan="1">Yijun Chen (Invited Expert)<br/> 
+      <td rowspan="1" colspan="1">Yijun Chen (Invited Expert)<br>
         Eric Q. Liu (Invited Expert)
       </td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Team Contacts<br />
         (FTE %: 2)</th>
-      <td rowspan="1" colspan="1">Richard Ishida<br/>Fuqiao Xue<br/></td>
+      <td rowspan="1" colspan="1">Richard Ishida<br>Fuqiao Xue<br></td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Usual Meeting Schedule</th>
@@ -130,8 +133,8 @@
 <section id="scope" class="scope">
 <h2>Scope</h2>
 <p>The proposal for the group originated from consultation with stakeholders and W3C members in China on how to help facilitate increased involvement in W3C activities around CSS, digital-publishing, and other Web technologies for the languages of China.</p>
-<p>In addition to those specifications, the group may review (but is by no means explicitly limited to reviewing) the following: 
-  
+<p>In addition to those specifications, the group may review (but is by no means explicitly limited to reviewing) the following:
+
 </p>
 <ul>
   <li>The work of the Internationalization Working Group.</li>
@@ -152,7 +155,7 @@
 <li>EPUB</li>
 </ul>
 
-<p>The group may also review draft specifications produced by Web API related working groups. Along with reviewing the above-mentioned specifications and related specifications, it is expected that the group will also gather comments and questions about those specifications, collect information about specific use cases in China for technologies defined in those specifications, and report the results of its activities as a group back to the Internationalization Working Group, as well as to other relevant groups - such as the HTML Working Group, CSS Working Group, SVG Working Group, etc.</p>
+<p>The group may also review draft specifications produced by Web API related working groups. Along with reviewing the above-mentioned specifications and related specifications, it is expected that the group will also gather comments and questions about those specifications, collect information about specific use cases in China for technologies defined in those specifications, and report the results of its activities as a group back to the Internationalization Working Group, as well as to other relevant groups - such as the CSS Working Group, SVG Working Group, WHATWG etc.</p>
 
 </section>
 
@@ -169,7 +172,7 @@
   <a href="https://www.w3.org/TR/clreq-gap/">Chinese Layout Gap Analysis</a>
 </li>
 </ul>
-<p>The group may also choose to produce other non-normative deliverables, such as test cases and error reports – under the terms of the Policies for Contribution of Test Cases to W3C, and in coordination with any relevant working groups. 
+<p>The group may also choose to produce other non-normative deliverables, such as test cases and error reports – under the terms of the Policies for Contribution of Test Cases to W3C, and in coordination with any relevant working groups.
 </p>
 
   <p>Documents can be produced in both Chinese and English, but there should always be an English version available, since people who don't speak Chinese are part of the target audience for the documents. In fact, opening up information to an international audience is an important aspect of the group's mission. In line with W3C policy, the authoritative version of a document will be the English one: this may be a translation from Chinese, or may be originated in English.</p>
@@ -195,17 +198,17 @@
       <ul>
         <li><a href="https://www.w3.org/International/">Internationalization Activity</a></li>
         <li><a href="https://www.w3.org/Style/CSS/">CSS Working Group</a></li>
-        <li><a href="https://www.w3.org/2019/html/">HTML Working Group</a></li>
+        <li><a href="https://whatwg.org/">WHATWG</a></li>
         <li><a href="https://unicode.org/">Unicode Consortium</a></li>
-        <li><a href="https://www.w3.org/2019/webapps/">Web Applications Working Group</a></li>
-        <li><a href="https://www.w3.org/2011/08/browser-testing-charter.html">Browser Testing and Tools Working Group</a></li>
-        <li><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></li> 
+        <li><a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a></li>
+        <li><a href="https://www.w3.org/testing/browser/">Browser Testing and Tools Working Group</a></li>
+        <li><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></li>
         <li><a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB 3 Working Group</a></li>
         <li><a href="https://www.w3.org/2018/chinese-web-ig/">Chinese Web Interest Group</a></li>
       </ul>
     </dd>
     <dt>Other Groups</dt>
-    <dd>The Chinese Text Layout Task Force is also expected to take advantage of opportunities for discussion and collaboration with existing groups and communities in China as well as groups and communities elsewhere.</dd> 
+    <dd>The Chinese Text Layout Task Force is also expected to take advantage of opportunities for discussion and collaboration with existing groups and communities in China as well as groups and communities elsewhere.</dd>
 </dl>
 </section>
 </section>
@@ -246,7 +249,7 @@
 <h2 id="decisions">Decision Policy</h2>
 
 <p>As explained in the Process Document (<a
-href="https://www.w3.org/Consortium/Process/policies#Consensus">section 3.3</a>),
+href="https://www.w3.org/Consortium/Process/policies#Consensus">section 5.2.1, Consensus</a>),
 this group will seek to make decisions when there is consensus. In cases where there is a need to formally produce a group resolution about a particular issue, its Chair will put a question about the issue to the group and gather responses (including any formal objections); then, after due consideration of all the responses, the Chair will record a group resolution (possibly after a formal vote and also along with responding to any formal objections).</p>
 </section>
 
@@ -318,19 +321,11 @@ Implementation</a>.</p>
   Richard Ishida, Fuqiao Xue
 </address>
 
-<p class="copyright">
-  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-  2021
-  <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-  (
-  <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-  <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-  <a href="https://www.keio.ac.jp/">Keio</a>,
-  <a href="https://ev.buaa.edu.cn/">Beihang</a>
-  ), All Rights Reserved.
-
-  <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
-</p>
+<p class="copyright">Copyright © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
 
 </body>
 </html>


### PR DESCRIPTION
This PR makes the following changes to the charter:

* Markup fixes
* Update the end date from 2023 to 2025
* Update a few links
* Add the WHATWG to the list of relevant groups
