### PR TITLE
Translate part of unbreakable_marks_punctuation to Chinese

### DIFF
--- a/index.html
+++ b/index.html
@@ -1891,8 +1891,8 @@ var respecConfig = {
         </h5>
 
         <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2&nbsp;em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，在行间应为一体，视作一个字符存在，不能为了适配分行而拆成两行。但若遇连续多个标点符号，允许按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法将其拆成两行。如果强制将其排列于一行，前行的字距可能会过大，从而影响整体排版的美观。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，在行間應為一體，視作一個字元存在，不得以適配分行之由拆至二行。但若遇連續多個標點符號，允許按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法將其拆成兩行。如果強制將其排列於一行，前行的字距可能會過大，從而影響整體排版的美觀。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，应视为一体，不能拆成两行。但若这些标点符号连续出现多个，允许按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法将其拆成两行。如果强制将其排列于一行，前行的字距可能会过大，从而影响整体排版的美观。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，應視為一體，不能拆成兩行。但若這些標點符號連續出現多個，允許按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法將其拆成兩行。如果強制將其排列於一行，前行的字距可能會過大，從而影響整體排版的美觀。</p>
         <ol>
           <li id="id90">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Two-em dash.</span></p>

--- a/index.html
+++ b/index.html
@@ -1891,8 +1891,8 @@ var respecConfig = {
         </h5>
 
         <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2&nbsp;em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，在行间应为一体，视作一个字符存在，不能为了适配分行而拆成两行。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，在行間應為一體，視作一個字元存在，不得以適配分行之由拆至二行。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，在行间应为一体，视作一个字符存在，不能为了适配分行而拆成两行。但若遇连续多个标点符号，允许按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法将其拆成两行。如果强制将其排列于一行，前行的字距可能会过大，从而影响整体排版的美观。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，在行間應為一體，視作一個字元存在，不得以適配分行之由拆至二行。但若遇連續多個標點符號，允許按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法將其拆成兩行。如果強制將其排列於一行，前行的字距可能會過大，從而影響整體排版的美觀。</p>
         <ol>
           <li id="id90">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Two-em dash.</span></p>

--- a/index.html
+++ b/index.html
@@ -5757,10 +5757,10 @@ var respecConfig = {
     <span its-locale-filter-list="zh-hant" lang="zh-hant">致謝</span>
   </h2>
 
-  <p its-locale-filter-list="en" lang="en">Special thanks  to the following people who contributed to this document (contributors' names listed in in alphabetic order). </p>
+  <p its-locale-filter-list="en" lang="en">Special thanks to the following people who contributed to this document (contributors' names listed in in alphabetic order). </p>
   <p its-locale-filter-list="zh-hans" lang="zh-hans">感谢以下参与者对本文档的建议与补充（依字母及拼音顺序排列）：</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">感謝以下參與者對本文檔的建議與補充（依字母及拼音順序排列）：</p>
-  <p class="acknowledgement">Addison Phillips, Buernia, 陳穎青, Du Yuang, Hao Chen, Hawkeyes Wind, 贺师俊 John Hax (百姓网), 侯迈 MieMie (豆瓣), NFSL2001, Jiang Jiang (Opera), 吕康豪 Kang-hao Lu (BGI), 李喆明 Austin Lee, Percy Ma, 权循真 Xidorn Quan (Mozilla), SyaoranHinata, technommy, and Virgil Ming.</p>
+  <p class="acknowledgement">Addison Phillips, Buernia, 陳穎青, Du Yuang, Hao Chen, Hawkeyes Wind, 贺师俊 John Hax (百姓网), 侯迈 MieMie (豆瓣), NFSL2001, Jiang Jiang (Opera), 吕康豪 Kang-hao Lu (BGI), 李喆明 Austin Lee, Percy Ma, phy25, 权循真 Xidorn Quan (Mozilla), SyaoranHinata, technommy, and Virgil Ming.</p>
   <p its-locale-filter-list="en" lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/clreq/graphs/contributors">GitHub contributors list</a>.</p>
   <p its-locale-filter-list="zh-hans" lang="zh-hans">欲了解最新的参与者信息，请参看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub贡献者列表</a>。</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">欲了解最新的參與者信息，請參看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub貢獻者列表</a>。</p>


### PR DESCRIPTION
Fixes w3c/clreq#546.

English text introduced by [0cb9960a463e68afd58ed9c86ad32a5859b14a9d](https://github.com/w3c/clreq/commit/0cb9960a463e68afd58ed9c86ad32a5859b14a9d#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L831).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/phy25/clreq/pull/548.html" title="Last updated on Jun 18, 2023, 10:38 PM UTC (57d1652)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/548/ee2576c...phy25:57d1652.html" title="Last updated on Jun 18, 2023, 10:38 PM UTC (57d1652)">Diff</a>