### PR TITLE
Use 'text-align: justify;' for Chinese text

### DIFF
--- a/local.css
+++ b/local.css
@@ -33,10 +33,12 @@ sans-serif: Fallback
 
 [lang=zh-hant] {
   font-family: 'Punctuation TC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', 'PingFang TC', 'Noto Sans TC', 'Noto Sans CJK TC', 'Heiti TC', 'Microsoft JhengHei', sans-serif;
+  text-align: justify;
 }
 
 [lang=zh-hans] {
   font-family: 'Punctuation SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', 'PingFang SC', 'Noto Sans SC', 'Noto Sans CJK SC', 'Heiti SC', 'DengXian', 'Microsoft YaHei', sans-serif;
+  text-align: justify;
 }
 
 h2 {


### PR DESCRIPTION
Fix #543.