### PR TITLE
Fix awkward English transalation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3065,7 +3065,7 @@ var respecConfig = {
               <p its-locale-filter-list="zh-hant" lang="zh-hant">比照<a href="#prohibition_rules_for_line_start_end">避頭點的處理方式</a>，由前一行取一字至末行，前一行採均排。</p>
             </li>
             <li id="id166">
-              <p its-locale-filter-list="en" lang="en">Delete some characters from the previous paragraph so that there will be enough space to move the orphan back to the previous line.</p>
+              <p its-locale-filter-list="en" lang="en">Delete some characters from the paragraph so that there will be enough space to move the orphan back to the previous line.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">删减该段落文字，使孤字缩进段落前一行。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">刪減該段落文字，使孤字縮進段落前一行。</p>
             </li>

--- a/index.html
+++ b/index.html
@@ -3065,7 +3065,7 @@ var respecConfig = {
               <p its-locale-filter-list="zh-hant" lang="zh-hant">比照<a href="#prohibition_rules_for_line_start_end">避頭點的處理方式</a>，由前一行取一字至末行，前一行採均排。</p>
             </li>
             <li id="id166">
-              <p its-locale-filter-list="en" lang="en">Delete some character(s) from the previous paragraph so that there will be enough space to move the orphan back to the previous line.</p>
+              <p its-locale-filter-list="en" lang="en">Delete some characters from the previous paragraph so that there will be enough space to move the orphan back to the previous line.</p>
               <p its-locale-filter-list="zh-hans" lang="zh-hans">删减该段落文字，使孤字缩进段落前一行。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">刪減該段落文字，使孤字縮進段落前一行。</p>
             </li>


### PR DESCRIPTION
Closes #557 

This PR removes the awkard (s) from the English translation in section 3.4.4


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/564.html" title="Last updated on Aug 15, 2023, 9:00 AM UTC (537f20d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/564/0466821...537f20d.html" title="Last updated on Aug 15, 2023, 9:00 AM UTC (537f20d)">Diff</a>