### PR TITLE
Remove the style for .uname

### DIFF
--- a/local.css
+++ b/local.css
@@ -129,12 +129,6 @@ kbd {
 
 code { color: #A52A2A; }
 
-.uname {
-  text-transform: uppercase;
-  font-size: 85%;
-  letter-spacing:0.03em;
-}
-
 #langSwitch {
 	position: fixed;
 	top: -14px;


### PR DESCRIPTION
Since it's in tr-design now: https://github.com/w3c/tr-design/pull/323