### PR TITLE
Fix #588 & #589

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,7 @@ var respecConfig = {
           <li id="id18">
             <p its-locale-filter-list="en" lang="en">To deal with rules that forbid certain characters at the beginning or end of a line. When a punctuation mark which is not supposed to be positioned at the end of a line happens to appear there, even inter-character space setting is used to move the character before the punctuation mark to the next line together with the punctuation mark. When a punctuation mark, which is not supposed to be positioned at the beginning of a line, happens to appear there, it is necessary to move the last character from the previous line to the beginning of the next line, and there will be one or two (sometimes more) empty spaces left in the previous line. Even inter-character space setting is used to unify the length of each line and justify them.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">行首行尾禁则。当该行行尾遇到不能置于行尾的标点符号，而必须将标点符号与前一汉字移至次行时；或次行行首遇到不能置于行首的标点符号，而必须将移动前一行汉字于次行时，就会在行尾产生一到两字（甚至以上）的空白。由于中文书籍各行首尾对齐是重要的排版规则，此时就会利用均排将两字（以及以上）空白均分至该行各字字距。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">行首行尾禁則。當該行行尾遇到不能置於行尾的標點符號，而必須將標點符號與前一漢字移至次行時；或次行行頭遇到不能置於行頭的標點符號，而必須將移動前一行漢字於次行時，就會於行尾產生一到二字（甚至以上）的空白。由於中文書籍各行首尾對齊是重要的排版規則，此時就會利用均排將二字（以及以上）空白均分至該行各字字距。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">行首行尾禁則。當該行行尾遇到不能置於行尾的標點符號，而必須將標點符號與前一漢字移至次行時；或次行行首遇到不能置於行首的標點符號，而必須將移動前一行漢字於次行時，就會於行尾產生一到二字（甚至以上）的空白。由於中文書籍各行首尾對齊是重要的排版規則，此時就會利用均排將二字（以及以上）空白均分至該行各字字距。</p>
           </li>
           <li id="id19">
             <p its-locale-filter-list="en" lang="en">Even inter-character space setting is used when the number of characters in a table head differs from the table content, such as for person names, so as to justify the table.</p>
@@ -775,8 +775,8 @@ var respecConfig = {
         </li>
         <li id="id41">
           <p its-locale-filter-list="en" lang="en"><span class="leadin">Pages for table of contents, index, and bibliography:</span> These pages’ layout is also based on the type area of body text. In practice, additional paddings might be attached onto the start and the end of the lines. Furthermore, these pages might be set in multiple columns while the body text is single column.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">目录、索引、参考文献：</span>此类页面也以基本版式为基准进行排版。但具体实践中，行头、行尾常会添加额外留白；此外，在正文采用单栏排版的同时，此类页面也有可能分为多栏。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">目錄、索引、參考文獻：</span>此類頁面也以基本版式為基准進行排版。但具體實踐中，行頭、行尾常會添加額外留白；此外，在正文採用單欄排版的同時，此類頁面也有可能分為多欄。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">目录、索引、参考文献：</span>此类页面也以基本版式为基准进行排版。但具体实践中，行首、行尾常会添加额外留白；此外，在正文采用单栏排版的同时，此类页面也有可能分为多栏。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">目錄、索引、參考文獻：</span>此類頁面也以基本版式為基准進行排版。但具體實踐中，行首、行尾常會添加額外留白；此外，在正文採用單欄排版的同時，此類頁面也有可能分為多欄。</p>
         </li>
       </ol>
     </section>
@@ -2247,7 +2247,7 @@ var respecConfig = {
 
       <p its-locale-filter-list="en" lang="en">In horizontal writing mode, the basic approach uses proportional fonts to represent Western alphas and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4&nbsp;em, except at the line start or end.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文字母使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文字母使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文字母使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行首或行尾時，則毋須加入空白。</p>
       <div class="note" id="n036">
         <p its-locale-filter-list="en" lang="en">Another approach is to use a Western word space (<span class="uname" translate="no">U+0020 SPACE</span>), in which case the width depends on the font in use.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">或可使用西文词间空格（<span class="uname" translate="no">U+0020 SPACE</span> [ ]，其宽度随不同字体有所变化）。</p>
@@ -2285,7 +2285,7 @@ var respecConfig = {
         <li id="id111">
           <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western text with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Western text compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western alpha or European numeral, up to a width of 1/4&nbsp;em, except at the line start or end.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">采用比例字体，将文字顺时针旋转90°配置。当文中的西文为一般单词、语句或四位数以上的阿拉伯数字时，采用此方法配置。汉字与西文字母、阿拉伯数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">採用比例字體，將文字順時針旋轉90度配置。當文中的西字為一般單字詞、語句，或阿拉伯數在四位數以上時，採用此方法配置。漢字與西文字母、阿拉伯數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">採用比例字體，將文字順時針旋轉90度配置。當文中的西字為一般單字詞、語句，或阿拉伯數在四位數以上時，採用此方法配置。漢字與西文字母、阿拉伯數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行首或行尾時，則毋須加入空白。</p>
           <figure id="latin-90-clockwise-2">
             <img its-locale-filter-list="en" lang="en" src="images/en/latin-90-clockwise.svg" alt="Example of Western alphas rotated 90 degrees clockwise." width="124" height="188">
             <img its-locale-filter-list="zh-hans" lang="zh-hans" src="images/zh/latin-90-clockwise-Hans.svg" alt="顺时针旋转90°的西文字母示例" width="124" height="188">
@@ -2340,7 +2340,7 @@ var respecConfig = {
         <li id="id116">
           <p its-locale-filter-list="en" lang="en">Justified text alignment is an important feature of Chinese composition. It is harder to align text as expected when a line contains Western characters. Typically, spacing or tracking is applied equally across the line, but such adjustments are only applied between Han characters, or between a Han character and a Western character. The spacing is not equally distributed between characters in Western words and/or European numerals.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">由于中文排版强调行首与行尾对齐，当行内包含西文时，较难对齐，这时多使用均排的方式处理。均排时，各西文词组间、阿拉伯数字间的空格，以及西文字母与阿拉伯数字之间不使用均排，仅调整汉字、汉字与西文间的字距或空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">由於中文排版強調行頭與行尾對齊，當行內包含西文時，較難對齊，這時多使用均排的方式處理。均排時，各西文詞組間、阿拉伯數字間之空格，以及西文字母與阿拉伯數字之間不使用均排，僅調整漢字、漢字與西文間的字距或空白。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">由於中文排版強調行首與行尾對齊，當行內包含西文時，較難對齊，這時多使用均排的方式處理。均排時，各西文詞組間、阿拉伯數字間之空格，以及西文字母與阿拉伯數字之間不使用均排，僅調整漢字、漢字與西文間的字距或空白。</p>
         </li>
       </ol>
       <p its-locale-filter-list="en" lang="en">Exceptions are made in the following cases:</p>
@@ -2350,7 +2350,7 @@ var respecConfig = {
         <li id="id117">
           <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or <a href="#term.european-numerals" class="termref">European numerals</a> before the line start or after the line end are not justified.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">位于行首的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之前、位于行尾的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之后不调整字距或加入空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行頭的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之前、位於行尾的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之後不調整字距或加入空白。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行首的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之前、位於行尾的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之後不調整字距或加入空白。</p>
         </li>
         <li id="id118">
           <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or European numerals is not adjusted before or after Chinese commas or full stops, nor after Chinese opening and before Chinese closing brackets.</p>
@@ -2995,8 +2995,8 @@ var respecConfig = {
       <span id="line_head_indent_of_paragraphs"></span>
 
       <p its-locale-filter-list="en" lang="en">The paragraph indent is the indentation of the line start by a fixed amount, starting from the line start side of the type area (in the case of one column) or of the column area (in the case of several columns). This method is usually applied for quotations, poetry or subtitles in a paragraph or between the paragraphs.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">段落缩排是指将版心（单栏排版时）以及栏的范围（多栏排版时）由行头侧以指定的量，将文字开始位置向后移动的处理。此种缩排方式多应用于段落内或段落间引用文章、诗词及标题等。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">段落縮排係指將版心（單欄排版時）以及欄的範圍（多欄排版時）由行頭側以指定的量，將文字開始位置向後移動的處理。此種縮排方式多應用於段落內或段落間引用文章、詩詞及標題等。</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">段落缩排是指将版心（单栏排版时）以及栏的范围（多栏排版时）由行首侧以指定的量，将文字开始位置向后移动的处理。此种缩排方式多应用于段落内或段落间引用文章、诗词及标题等。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">段落縮排係指將版心（單欄排版時）以及欄的範圍（多欄排版時）由行首側以指定的量，將文字開始位置向後移動的處理。此種縮排方式多應用於段落內或段落間引用文章、詩詞及標題等。</p>
       <div class="note" id="n047">
         <p its-locale-filter-list="en" lang="en">Generally speaking, the characters in the paragraphs which apply paragraph indent should be the same as the characters in the body content. Sometimes, due to the different typefaces, the size of characters in the paragraphs which apply paragraph indent differ from the characters in the body content. In this case, a certain amount of space might be added before and after the indent paragraph so as to make a clear distinction from other paragraphs. The space added is usually an integer times the height of paragraphs in the body content</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">一般而言以缩排处理的段落，文字尺寸与内文相同。有时会调整字体，与内文做出差异。或在前后段落间加入段落间距，使该段落与内文段落差异更为明显。加入间距所占空间应为内文行的整数倍。</p>
@@ -3689,7 +3689,7 @@ var respecConfig = {
         <li id="id183">
           <p its-locale-filter-list="en" lang="en"><span class="leadin">Alignment of headings (inline direction):</span> In the case of horizontal writing mode, large headings and medium headings are in most cases center-aligned. In the case of vertical writing mode, headings are usually aligned to the line start with some indent.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">对齐横排的大标与中标使用置中对齐的案例相当多，但直排时，则多使用对齐行首或下字。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">對齊橫排的大標與中標使用置中對齊的案例相當多，但直排時，則多使用對齊行頭或下字。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">對齊橫排的大標與中標使用置中對齊的案例相當多，但直排時，則多使用對齊行首或下字。</p>
           <div class="note" id="n058">
             <p its-locale-filter-list="en" lang="en">The number of characters of line start indent for a heading depends on the heading level. If the heading level is higher, the indent character number is less, if the heading level is lower, the number of indent characters is more. The character size is based on the main text of the type area. The difference in character numbers is usually around two characters.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">下字时，下字的量一般使用版心设定文字尺寸的两倍汉字的长宽。大标、中标、小标下字量，由各排版者决定，无一定规则。</p>
@@ -5427,8 +5427,8 @@ var respecConfig = {
         <td>justified alignment</td>
         <td>
           <p its-locale-filter-list="en" lang="en">The alignment method to align on both the left and right ends of each line of one paragraph text.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">一种段落每行的行头行尾分别对齐的排版方式。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">一種段落每行的行頭行尾分別對齊的排版方式。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">一种段落每行的行首行尾分别对齐的排版方式。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">一種段落每行的行首行尾分別對齊的排版方式。</p>
         </td>
       </tr>
       <tr id="term.fullwidth">

--- a/index.html
+++ b/index.html
@@ -2369,8 +2369,8 @@ var respecConfig = {
       </h4>
 
       <p its-locale-filter-list="en" lang="en">Due to the fact that each Han character is of the same width, not only should characters at the start and end of a line be aligned but it is also a requirement for characters within blocks of Han text to be aligned both vertically and horizontally, whether in vertical or horizontal writing mode. When Western alphas or European numerals are present, this principle is harder to achieve. Possible approaches are listed below:</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字各字等宽的性质，无论在直排或横排的情况下，除了行齐首尾对齐外，亦求各行间的各个汉字能够纵横对齐。若遇西文字母或阿拉伯数字采用比例字体，难以满足这项原则时，处理方式如下：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文字母或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字各字等宽的性质，无论在直排或横排的情况下，除了行两端对齐外，亦求各行间的各个汉字能够纵横对齐。若遇西文字母或阿拉伯数字采用比例字体，难以满足这项原则时，处理方式如下：</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行兩端對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文字母或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
       <ol>
         <li id="id119">
           <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between a Han character and an alphanumeric, it is possible to use flexible spacing of up to 1/2&nbsp;em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han characters before and after a Western text span snap to the grid lines.</p>
@@ -5421,9 +5421,9 @@ var respecConfig = {
         </td>
       </tr>
       <tr id="term.justified-alignment">
-        <td>齊頭尾對齊</td>
-        <td>齐头尾对齐</td>
-        <td>qítóuwěi duìqí</td>
+        <td>兩端對齊</td>
+        <td>两端对齐</td>
+        <td>liǎngduān duìqí</td>
         <td>justified alignment</td>
         <td>
           <p its-locale-filter-list="en" lang="en">The alignment method to align on both the left and right ends of each line of one paragraph text.</p>


### PR DESCRIPTION
This revision is based on the discussion per [editors’ call on 26 Jun 2024](https://www.w3.org/2024/06/26-clreq-minutes.html#t02) to fix issues #588 and #589.

- Replace the term “行头” or “行頭” with “行首” in SC and TC.
- Replace the term “齐首尾对齐” or “齐头尾对齐” with “两端对齐” in SC.
- Replace the term “齊頭尾對齊” with “兩端對齊” in TC.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/626.html" title="Last updated on Jul 5, 2024, 6:06 AM UTC (d971de3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/626/1ec0d55...realfish:d971de3.html" title="Last updated on Jul 5, 2024, 6:06 AM UTC (d971de3)">Diff</a>