### PR TITLE
Restructure clreq per standardised headings

### DIFF
--- a/indexNEW.html
+++ b/indexNEW.html
@@ -2358,9 +2358,9 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2&nbsp;em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines as described in [[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，应视为一体，不能拆成两行。但若这些标点符号连续出现多个，允许按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法将其拆成两行。如果强制将其排列于一行，前行的字距可能会过大，从而影响整体排版的美观。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，應視為一體，不能拆成兩行。但若這些標點符號連續出現多個，允許按照[[[#handling_western_text_in_chinese_text_using_proportional_western_fonts]]]的做法將其拆成兩行。如果強制將其排列於一行，前行的字距可能會過大，從而影響整體排版的美觀。</p>
+        <p its-locale-filter-list="en" lang="en" class="checkme">The following punctuation marks should be considered as one unit and take 2&nbsp;em. They should not be separated into two lines. In cases where multiples of such punctuation marks appear together, it is allowed to separate them into two lines. If they were forced to remain on one line, it might cause too much space between the characters in the previous line and decrease the aesthetics of the entire composition.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下标点符号占用两个汉字的空间，应视为一体，不能拆成两行。但若这些标点符号连续出现多个，允许将其拆成两行。如果强制将其排列于一行，前行的字距可能会过大，从而影响整体排版的美观。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下標點符號佔用二個漢字的空間，應視為一體，不能拆成兩行。但若這些標點符號連續出現多個，允許將其拆成兩行。如果強制將其排列於一行，前行的字距可能會過大，從而影響整體排版的美觀。</p>
         <ol>
           <li id="id90">
             <p its-locale-filter-list="en" lang="en"><a href="#id82">Two-em dash</a></p>

--- a/indexNEW.html
+++ b/indexNEW.html
@@ -147,8 +147,8 @@ var respecConfig = {
       </li>
       <li id="id4">
         <p its-locale-filter-list="en" lang="en"> There are two writing modes: vertical and horizontal. The former is often seen in publications from Taiwan, Hong Kong etc.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">中文的书写方向有直排及横排两种，其中，前者多见于台湾、香港等地的中文出版品。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">中文的書寫方向有直排及橫排二種，其中，前者多見於台灣、香港等地的中文出版品。</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">中文的行文模式有直排及横排两种，其中，前者多见于台湾、香港等地的中文出版品。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">中文的行文模式有直排及橫排二種，其中，前者多見於台灣、香港等地的中文出版品。</p>
       </li>
       <li id="id5">
         <p its-locale-filter-list="en" lang="en"> In principal, the characters, including Han characters (Hanzi) and punctuation, used in Chinese composition are squares with the ratio of 1:1, and are seamlessly arranged with one another.</p>
@@ -1675,7 +1675,7 @@ var respecConfig = {
           </li>
           <li id="id122">
             <p its-locale-filter-list="en" lang="en" class="leadin">Romanization.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="leadin checkme">罗马拼音</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="leadin">罗马拼音</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="leadin">羅馬拼音</p>
             <p its-locale-filter-list="en" lang="en">Hanyu Pinyin (汉语拼音), now the official standard in Mainland China, uses the Latin alphabet to transcribe the Modern Standard Chinese (Mandarin) pronunciations of Han characters. The most common use case in Mainland China is to indicate the pronunciation for all characters of the full text with Hanyu Pinyin. In Taiwan and areas that use Chinese dialects in China, the arrangement of the Taiwanese Romanization System for Minnan (<span lang="zh-hant">台灣閩南語羅馬字</span>), or romanization systems of other Chinese dialects are similar to those of Hanyu Pinyin.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">使用拉丁字母的汉语拼音是中国大陆推行的现代标准汉语（普通话）标音与拉丁转写方案，汉语拼音的全文标音也是中国大陆现代最常见的行间注用例。在中国大陆与台湾，台湾闽南语罗马字拼音等各种汉语方言的拉丁字母标音方案也有与汉语拼音情况类似的行间注用例。</p>
@@ -2210,7 +2210,7 @@ var respecConfig = {
 
           <p its-locale-filter-list="en" lang="en">Emphasis Dots shall be center-aligned with its corresponding character; interlinear lines must be correspond with the length and quantity of content they are marking out. As such, if there are multiple instances which need to be marked out with interlinear lines, multiple interlinear lines need to be used. Interlinear lines cannot be arbitrarily broken up. And a single interlinear line cannot be composed out of multiple fragments. For example, if there are two adjacent Proper Nouns, even if the text being marked out is set solid, both Proper Nouns must be clearly marked with two Proper Noun Marks that are distinguishable from one another. In this instance, a single Proper Noun Mark must not be used, because this would cause the two Proper Nouns to be misunderstood as a single Proper Noun.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">着重号应与所指示的字符居中对齐；行间线应与所标注内容的长短、数量均要保持一致，即，有几个标注项目就用几条线段，不能任意从中断开，也不能用多条线段拼接组合。比如，相邻的两个专名，即使所标注的正文汉字是密排，两个专名要用两条专名线，中间的断开要能够辨认；此时不能用一条专名线连起来标注，否则连续的两个专名会被误认为是一个专名。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">著重號應與所指示的字符居中對齊；行間線應與所標註內容的長短、數量均要保持一致，即，有幾個標註項目就用幾條線段，不能任意從中斷開，也不能用多條線段拼接組合。比如，相鄰的兩個專名，即使所標註的正文漢字是密排，兩個專名要用兩條專名線，中間的斷開要能夠辨認；此時不能用一條專名線連起來標註，否則連續的兩個專名會被誤認為是一個專名。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">著重號應與所指示的字元居中對齊；行間線應與所標註內容的長短、數量均要保持一致，即，有幾個標註項目就用幾條線段，不能任意從中斷開，也不能用多條線段拼接組合。比如，相鄰的兩個專名，即使所標註的正文漢字是密排，兩個專名要用兩條專名線，中間的斷開要能夠辨認；此時不能用一條專名線連起來標註，否則連續的兩個專名會被誤認為是一個專名。</p>
 
           <p its-locale-filter-list="en" lang="en">Interlinear marks must be as close to the marked text as possible.<br>The thickness and size of the interlinear lines and emphasis dots is determined by the font design and typesetting rendering engine, but even though there is no absolute limitation, the sizing of these interlinear marks must be harmonious with the font size and letter-spacing of the marked text.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行间标点应尽量紧贴所标注汉字一侧。<br>行间线、着重号的大小或粗度取决于字体和排版引擎的设计，虽然没有绝对限制，但显然尺寸上应与所标汉字字号、字距相匹配。</p>
@@ -2229,7 +2229,7 @@ var respecConfig = {
 
           <p its-locale-filter-list="en" lang="en">In accordance to what was explained in the first general guidance, even after the letter-spacing is increased, Emphasis Dots must continue to be center-aligned with the text they are marking</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">根据上述通则 1. 拉开字距后，着重号依旧应与字符居中对齐而不能错位。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">根據上述通則 1. 拉開字距後，著重號依舊應與字符居中對齊而不能錯位。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">根據上述通則 1. 拉開字距後，著重號依舊應與字元居中對齊而不能錯位。</p>
         </li>
         <li id="single-sided-setting">
           <p>
@@ -2712,7 +2712,7 @@ var respecConfig = {
           行内夹杂了<a href="#term.european-numerals" class="termref">阿拉伯数字</a>、西文字母等非一个汉字字宽的字符；
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-          行內夾雜了<a href="#term.european-numerals" class="termref">阿拉伯數字</a>、西文字母等非一個漢字字寬的字符；
+          行內夾雜了<a href="#term.european-numerals" class="termref">阿拉伯數字</a>、西文字母等非一個漢字字寬的字元；
         </p>
       </li>
       <li>
@@ -2867,7 +2867,7 @@ var respecConfig = {
             行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定“5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。”
           </p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全形字符則應占半形字符的寬度（即半個字位置），以使視覺效果更美觀。」
+            行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全形字元則應占半形字元的寬度（即半個字位置），以使視覺效果更美觀。」
           </p>
         </aside>
       </li>
@@ -3029,7 +3029,7 @@ var respecConfig = {
           若上述所有项目均无法调整，或调整之后依旧无法达到预设行长，则只能针对剩余所有字符间距，进行同时、同等量拉伸，但是：
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-          若上述所有項目均無法調整，或調整之後依舊無法達到預設行長，則只能針對剩餘所有字符間距，進行同時、同等量拉伸，但是：
+          若上述所有項目均無法調整，或調整之後依舊無法達到預設行長，則只能針對剩餘所有字元間距，進行同時、同等量拉伸，但是：
         </p>
         <ol type="a">
           <li>
@@ -3051,7 +3051,7 @@ var respecConfig = {
               避免对连接号、分隔号与其前后的字符进行拉伸处理。
             </p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-              避免對連接號、分隔號與其前後的字符進行拉伸處理。
+              避免對連接號、分隔號與其前後的字元進行拉伸處理。
             </p>
           </li>
         </ol>

--- a/indexNEW.html
+++ b/indexNEW.html
@@ -298,9 +298,9 @@ var respecConfig = {
 <p its-locale-filter-list="zh-hans" lang="zh-hans">中文的文本方向分为<a href="#term.vertical-writing-mode" class="termref">直排</a>与<a href="#term.horizontal-writing-mode" class="termref">横排</a>。其中，台湾、香港的中文出版品适用直排与横排；中国大陆的出版品则多为横排，直排书籍的案例较少。</p>
 <p its-locale-filter-list="zh-hant" lang="zh-hant">中文的文本方向分為<a href="#term.vertical-writing-mode" class="termref">直排</a>與<a href="#term.horizontal-writing-mode" class="termref">橫排</a>。其中，台灣、香港的中文出版品適用直排與橫排；中國大陸的出版品則多為橫排，直排書籍的案例較少。</p>
 <div class="note" id="n012">
-<p its-locale-filter-list="en" lang="en">Ever since the letterpress printing period, the characters and punctuation marks used for Chinese composition have basically been designed to have a square character frame. Thus the same collection of printing types can be used in either vertical writing mode or horizontal writing mode, simply by changing the direction of text. However, some adjustments will be needed for the punctuation marks so as to match the writing direction of the characters and their composition. This is described in more detail in [[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]. </p>
-<p its-locale-filter-list="zh-hans" lang="zh-hans">中文所使用的汉字与标点符号，原则上都是正方形的文字，自活字排版时代起，无论直、横排，都能使用相同的活字排列。但部分标点符号需配合文字书写方向调整字面分布及方向，见[[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]节之詳述。</p>
-<p its-locale-filter-list="zh-hant" lang="zh-hant">中文所使用的漢字與標點符號，原則上都是正方形的文字，自活字排版時代起，無論直、橫排，都能使用相同的活字排列。但部分標點符號需配合文字書寫方向調整字面分布及方向，見[[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]節之詳述。</p>
+<p its-locale-filter-list="en" lang="en">Ever since the letterpress printing period, the characters and punctuation marks used for Chinese composition have basically been designed to have a square character frame. Thus the same collection of printing types can be used in either vertical writing mode or horizontal writing mode, simply by changing the direction of text. However, some adjustments will be needed for the punctuation marks so as to match the writing direction of the characters and their composition. This is described in more detail in [[[#major_differences_between_horizontal_and_vertical_writing_modes]]]. </p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">中文所使用的汉字与标点符号，原则上都是正方形的文字，自活字排版时代起，无论直、横排，都能使用相同的活字排列。但部分标点符号需配合文字书写方向调整字面分布及方向，见[[[#major_differences_between_horizontal_and_vertical_writing_modes]]]节之詳述。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">中文所使用的漢字與標點符號，原則上都是正方形的文字，自活字排版時代起，無論直、橫排，都能使用相同的活字排列。但部分標點符號需配合文字書寫方向調整字面分布及方向，見[[[#major_differences_between_horizontal_and_vertical_writing_modes]]]節之詳述。</p>
 </div>
 <div class="note" id="n014">
 <p its-locale-filter-list="en" lang="en">Traditionally, Chinese publications were composed mainly in vertical writing mode, and this tradition has been largely preserved in Taiwan and Hong Kong. However, with the increasing amount of translated publications and mixed-text publications, and the default mode of writing in word processors, horizontal writing mode is becoming more and more popular. In Taiwan, government departments, educational materials and books on natural science mainly use horizontal writing mode while literary works such as poetry and novels still use vertical writing mode. Vertical writing mode still stands as an important cultural characteristic of regions where Traditional Chinese is used.</p>
@@ -372,6 +372,22 @@ var respecConfig = {
 </ul>
 </li>
 </ol>
+</li>
+<li id="glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks">
+  <p its-locale-filter-list="en" lang="en">The glyphs and usage of punctuation marks. There are no notable differences among different regions in the glyphs of punctuation marks. The major differences are their size and where the character face is positioned relative to the character frame.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的字形及用法。各地的标点符号在字形上未有显著差异，区别主要是符号的尺寸与字面分布。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的字形及用法。各地的標點符號在字形上未有顯著差異，區別主要係符號的尺寸與字面分布。</p>
+    <p its-locale-filter-list="en" lang="en">Punctuation marks used in Taiwan and Hong Kong are usually positioned in the vertical and horizontal center of the square space left for them; while in vertical writing mode and horizontal writing mode, some of the punctuation marks are positioned in different directions so as to mark the corresponding characters more accurately. In Mainland China, the punctuation marks are usually positioned following the characters they are supposed to mark; while some punctuation marks might be positioned in different directions due to the vertical or horizontal writing mode. Also, different writing modes might require different punctuation marks to fulfill the same function, e.g. horizontal writing mode requires curved quotation marks while vertical writing mode requires corner brackets.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">港台的标点多位于字面正中，部分标号在直、横排中使用不同的方向以准确地标注文字；中国大陆的标点多位于被标注文字的末端、字面始端，部分标号在直、横排中除了使用不同的方向外，亦有需要因文字书写方向替换符号形式的需求，如引号（横排使用弯引号，直排使用直角引号）。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">港台的標點多位於字面正中，部分標號在直、橫排中使用不同的方向以準確地標注文字；中國大陸的標點多位於受注文字的末端、字面始端，部分標號在直、橫排中除了使用不同的方向外，亦有需要因文字書寫方向替換符號形式的需求，如引號（橫排使用彎引號，直排使用直角引號）。</p>
+    <p its-locale-filter-list="en" lang="en">Pause or stop punctuation marks include the slight-pause comma, comma, semicolon, colon, period, question mark, exclamation mark, etc. They take the same dimensions as well as the direction as a character in their respective writing modes does. In Taiwan and Hong Kong, pause or stop punctuation marks are usually positioned in the vertical and horizontal center of the square space left for them. In Chinese Mainland, they are positioned in the top or bottom side in the space left for them following the marked characters. In horizontal writing mode, the pause or stop punctuation marks are placed at the lower left corner in the square space while in vertical writing mode, they are placed in the right upper corner.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">点号，包括：顿号、逗号、分号、冒号、句号、问号、叹号等，占一个汉字的大小，直、横排方向一致。港台的排版位于字面正中；中国大陆的排版则位于文字末端、字面始端偏顶端或底端一侧（横排时位于字面左下角，直排时位于字面右上角）。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">點號，包括：頓號、逗號、分號、冒號、句號、問號、驚嘆號等，佔一個漢字的大小，直、橫排方向一致。港台的排版位於字面正中；中國大陸的排版則位受注文字末端、字面始端偏頂端或底端一側（橫排時位字面左下角，直排時位字面右上角）。</p>
+
+    <figure id="region-specific-punctuation-example">
+      <img width="250" height="205" alt="GB/T 15834規定的標點位置" src="images/zh/locale_punctuation.png">
+      <figcaption><span its-locale-filter-list="en" lang="en">An example punctuation position for vertical writing mode in Mainland China</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中国大陆竖排标点位置示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">中國大陸直排標點位置範例。</span></figcaption>
+    </figure>
 </li>
 <li id="id65">
 <p its-locale-filter-list="en" lang="en">When the text contains Western alphas or <a href="#term.european-numerals" class="termref">European numerals</a>, the typesetting method is as follows:</p>
@@ -1021,96 +1037,8 @@ var respecConfig = {
     <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號與其他行內特性</span>
   </h2>
 
-  <section id="line_composition_rules_for_punctuation_marks">
-    <h3>
-      <span its-locale-filter-list="en" lang="en">Line Composition Rules for Punctuation Marks</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号与其排版</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號與其排版</span>
-    </h3>
-
-    <p its-locale-filter-list="en" lang="en">The usage of Chinese punctuation marks differs across different regions. One major difference is how the character face is handled and positioned relative to the character frame. Punctuation marks are usually center-aligned in the character frame in Taiwan and Hong Kong, while punctuation marks are positioned in the corner of the character frame on the side closest to the preceding text in the Chinese Mainland. The differences and the correct way to layout punctuation marks in different areas will be introduced in detail later.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">中文标点符号的排版在各地区有不同的处理方式，其中较显著的差异是其字面分布——台湾、香港多使用符号居中的字形样式，而中国大陆多使用符号尾随受注文字端的字形样式，并依直、横排有不同的处理。下文将详述各地中文标点的异同及准确的配置方式。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">中文標點符號的排版在各地區有不同的處理方式，其中較顯著的差異係其字面分布——台灣、香港多使用符號居中的字形樣式，而中國大陸多使用符號尾隨受注文字端的字形樣式，並依直、橫排有不同的處理。下文將詳述各地中文標點的異同及準確的配置方式。</p>
-    <p its-locale-filter-list="en" lang="en">Major typesetting differences between Traditional Chinese and Simplified Chinese include the positioning of punctuation and terminological variations. (See more at [[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]). </p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">在繁、简中文排版中，标点符号于字面上的位置与形状差异为二者主要的分歧点（详见[[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]节）。进行版式配置时，需要多加留意。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">在繁、簡中文排版中，標點符號於字面上的位置與形狀差異為二者主要的分歧點（詳見[[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]節）。進行版式配置時，需要多加留意。</p>
-
-    <div class="note" id="n020">
-      <p its-locale-filter-list="en" lang="en">CJKV punctuation marks use different glyphs which are visually distinct between languages. Unicode currently does not distinguish each of them with unique codepoints. Usually, we use typefaces corresponding to the locale of the written text or have the layout engines adjust the punctuation marks according to the languages automatically.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">中日韩越意音文字标点符号有地区上的字形与形态差异，但Unicode并未对其区分码位，标点多有共用。通常，排版时使用相应的字体进行配置，或由排版引擎自动调适。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">中日韓越意音文字標點符號有地區上的字形與形態差異，但Unicode並未對其區分碼位，標點多有共用。通常，排版時使用相應的字體進行配置，或由排版引擎自動調適。</p>
-    </div>
 
 
-    <p its-locale-filter-list="en" lang="en">Chinese punctuation marks are mainly divided into <a href="#term.pause-or-stop-punctuation-marks" class="termref">pause or stop punctuation marks</a> and <a href="#term.indication-punctuation-marks" class="termref">indicator punctuation marks</a>. Pause or stop punctuation marks are used to indicate pauses or the end of a sentence. Some of the pause or stop punctuation marks appear within a sentence, such as secondary commas, commas, semicolons, colons, etc., while others appear at the end of a sentence, such as periods, question marks and exclamation marks.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">中文标点符号主要分为<a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>和<a href="#term.indication-punctuation-marks" class="termref">标号</a>。点号相对于标号，用于表示语句的停顿或暂停。分为句内点号，如顿号、逗号、分号、冒号等；以及句末点号，如句号、问号、感叹号等。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">中文標點符號主要分爲<a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>和<a href="#term.indication-punctuation-marks" class="termref">標號</a>。點號相對於標號，用於表示語句的停頓或暫停。分為句內點號，如頓號、逗號、分號、冒號等；以及句末點號，如句號、問號、驚嘆號等。</p>
-
-    <p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses, two-em dashes, ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于点号，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於點號，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
-
-    <p its-locale-filter-list="en" lang="en">The content of the following section is mainly based on the content of <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) issued in Mainland China, as well as the <cite>Punctuation Guidance (2008 revised edition)</cite> issued by the Ministry of Education in Taiwan. The former is a recommended national standard while the latter is not mandatory for general publications but mainly used to regulate education materials like textbooks.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">本节主要基于中国大陆的《标点符号用法》（GB/T 15834—2011）及台湾教育部的《重订标点符号手册》（2008年修订版）。前者属推荐标准，后者主要用于规范教科书等教育书籍，对一般出版品不具强制性。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">本節主要基於中國大陸的《標點符號用法》（GB/T 15834—2011）及台灣教育部的《重訂標點符號手冊》（2008年修訂版）。前者屬推薦標準，後者主要用於規範教科書等教育書籍，對一般出版品不具強制性。</p>
-
-</section>
-
-
-
-
-<section id="glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Sizes and positions of Punctuation Marks</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的字形、尺寸与字面分布</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的字形、尺寸與字面分布</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">Please find a description of the glyphs and usage of punctuation marks at [[[#h_inline]]] and [[[#tables_of_chinese_punctuation_marks]]]. There are no notable differences among different regions in the glyphs of punctuation marks. The major differences are their size and where the character face is positioned relative to the character frame.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的字形及用法请见[[[#h_inline]]]节及[[[#tables_of_chinese_punctuation_marks]]]。各地的标点符号在字形上未有显著差异，区别主要是符号的尺寸与字面分布。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的字形及用法請見[[[#h_inline]]]節及[[[#tables_of_chinese_punctuation_marks]]]。各地的標點符號在字形上未有顯著差異，區別主要係符號的尺寸與字面分布。</p>
-      <p its-locale-filter-list="en" lang="en">Punctuation marks used in Taiwan and Hong Kong are usually positioned in the vertical and horizontal center of the square space left for them; while in vertical writing mode and horizontal writing mode, some of the punctuation marks are positioned in different directions so as to mark the corresponding characters more accurately. In Mainland China, the punctuation marks are usually positioned following the characters they are supposed to mark; while some punctuation marks might be positioned in different directions due to the vertical or horizontal writing mode. Also, different writing modes might require different punctuation marks to fulfill the same function, e.g. horizontal writing mode requires curved quotation marks while vertical writing mode requires corner brackets.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">港台的标点多位于字面正中，部分标号在直、横排中使用不同的方向以准确地标注文字；中国大陆的标点多位于被标注文字的末端、字面始端，部分标号在直、横排中除了使用不同的方向外，亦有需要因文字书写方向替换符号形式的需求，如引号（横排使用弯引号，直排使用直角引号）。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">港台的標點多位於字面正中，部分標號在直、橫排中使用不同的方向以準確地標注文字；中國大陸的標點多位於受注文字的末端、字面始端，部分標號在直、橫排中除了使用不同的方向外，亦有需要因文字書寫方向替換符號形式的需求，如引號（橫排使用彎引號，直排使用直角引號）。</p>
-      <p its-locale-filter-list="en" lang="en">Pause or stop punctuation marks include the slight-pause comma, comma, semicolon, colon, period, question mark, exclamation mark, etc. They take the same dimensions as well as the direction as a character in their respective writing modes does. In Taiwan and Hong Kong, pause or stop punctuation marks are usually positioned in the vertical and horizontal center of the square space left for them. In Chinese Mainland, they are positioned in the top or bottom side in the space left for them following the marked characters. In horizontal writing mode, the pause or stop punctuation marks are placed at the lower left corner in the square space while in vertical writing mode, they are placed in the right upper corner.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">点号，包括：顿号、逗号、分号、冒号、句号、问号、叹号等，占一个汉字的大小，直、横排方向一致。港台的排版位于字面正中；中国大陆的排版则位于文字末端、字面始端偏顶端或底端一侧（横排时位于字面左下角，直排时位于字面右上角）。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">點號，包括：頓號、逗號、分號、冒號、句號、問號、驚嘆號等，佔一個漢字的大小，直、橫排方向一致。港台的排版位於字面正中；中國大陸的排版則位受注文字末端、字面始端偏頂端或底端一側（橫排時位字面左下角，直排時位字面右上角）。</p>
-
-      <figure id="region-specific-punctuation-example">
-        <img width="250" height="205" alt="GB/T 15834規定的標點位置" src="images/zh/locale_punctuation.png">
-        <figcaption><span its-locale-filter-list="en" lang="en">An example punctuation position for vertical writing mode in Mainland China</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中国大陆竖排标点位置示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">中國大陸直排標點位置範例。</span></figcaption>
-      </figure>
-
-      <p its-locale-filter-list="en" lang="en">Bracket marks include quotation marks, parentheses, book title mark type B, etc. They should be positioned in pairs at either side of the marked character(s), have the same dimensions as a character, and the same direction as the characters. Bracket quotation marks have different positioning rules in different areas. In Taiwan, single quotation marks will be used first and then double quotation marks, whereas in Chinese Mainland, double quotation marks will be used first and then single quotation marks. Also, the writing mode should be taken into consideration as well. Horizontal writing mode requires curved quotation marks while vertical writing mode requires corner brackets.</p>
-	    <p its-locale-filter-list="zh-hans" lang="zh-hans">夹注符号，包括：引号、括号及双书名号（书名号乙式）等，位于文本的两侧，占一个汉字的大小、依文字书写方向使用相应的标注方向。其中，引号在各地分别采用不同的形式，台湾多使用先单、后双（依此类推）的配对形式；中国大陆则使用先双、后单（依此类推）的配对形式，并按照文字书写方向采用相应的符号（横排使用弯引号，直排使用直角引号）。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">夾注符號，包括：引號、括號及書名號乙式（雙書名號）等，位受注文本的二側，佔一個漢字的大小、依文字書寫方向使用相應的標注方向。其中，引號在各地別採用不同的形式，台灣多使用先單、後雙（依此類推）的配對形式； 中國大陸則使用先雙、後單（依此類推）的配對形式，並依文字書寫方向採用相應的符號（橫排使用彎引號，直排使用直角引號）。</p>
-      <p its-locale-filter-list="en" lang="en">Ellipses and two-em dashes, should be vertically and horizontally centered within their square frame, and should be one character in height and two characters in width. They are not supposed to be separated from one line to the next and should be positioned in the same direction as the characters.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">省略号、破折号等标号，位字面正中，占两个汉字的空间，并不得以适配分行之由断开或拆至两行，依文字书写方向使用相应的标注方向。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">刪節號、破折號等標號，位字面正中，佔兩個漢字的空間，並不得以適配分行之由斷開或拆至兩行，依文字書寫方向使用相應的標注方向。</p>
-      <p its-locale-filter-list="en" lang="en">Connector marks should take up the same dimensions as a single character, and be vertically and horizontally centered within its square frame. Among the connector marks, the EN DASH should have a short length to distinguish it from the Han character [一], which means one. And they should be positioned in the same direction as the characters they mark.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">连接号位于字面正中，占一个汉字的大小，其中，甲式连接号在横排时，符号的直线长度应稍小于汉字“一”以避免歧义，按照文字书写方向使用相应的标注方向。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">連接號位字面正中，佔一個漢字的大小，其中，甲式連接號在橫排時，符號的直線長度應稍小於漢字「一」以避免歧義，依文字書寫方向使用相應的標注方向。</p>
-      <p its-locale-filter-list="en" lang="en">Middle dots should be vertically and horizontally centered within their square frame and take up the same dimensions as a single character. The orientation of middle dots are the same in horizontal and vertical writing modes. To make more economical use of the available space, or to tighten the overall spacing, sometimes the character frame for a middle dot is only 1/2&nbsp;em in the inline direction.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">间隔号位于字面正中，占一个汉字的大小，直、横排方向一致。为了节省排版空间、使词组或数字较紧凑地排列，可以使用半个汉字大小的间隔号。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">間隔號位於字面正中，佔一個漢字的大小，直、橫排方向一致。為了節省排版空間、使詞組或數字較緊湊地排列，可以使用半個漢字大小的間隔號。</p>
-      <p its-locale-filter-list="en" lang="en">Interlinear marks should be positioned in a way that do not affect adjacent lines of the text. For proper noun marks and book title mark type A, they are meant to appear below the marked character (in horizontal writing mode, it would be positioned below the character, while in vertical writing mode, it would be positioned to the left of the character). For emphasis dots, in horizontal writing mode, the dot is positioned below the marked character, while in vertical writing mode, the dot is positioned to the right of the marked character.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">标注在行间的标号需以不影响上下行文字为原则进行配置。包括：专名号、甲式书名号等两个符号，位于被标注文字底端（横排位于文字下方、直排位于文字左侧）；着重号横排时位于文字底端（下方）、直排时位于文字顶端（右侧）。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">標注於行間的標號需以不影響上下行文字為原則進行配置。包括：專名號、甲式書名號等二個符號，位受注文字底端（橫排位文字下方、直排位文字左側）；着重號橫排時位受注文字底端（下方）、直排時位在受注文字頂端（右側）。</p>
-      <p its-locale-filter-list="en" lang="en">Solidi should be vertically and horizontally centered within the character frame. In <abbr class="exclude" title="Guobiao standards">GB</abbr> rules, it should take 1/2&nbsp;em, whereas in Taiwan, there is no clear rule about its dimensions but most publications will give them the same dimensions as a single character.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">分隔号位于字面正中，中国大陆的国标规定排版时占半个汉字的大小；而在台湾则未有相关的规定，但多数出版品使用一个汉字的大小。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">分隔號位於字面正中，中國大陸的國標規定排版時佔半個漢字的大小；而在台灣則未有相關的規定，但多數出版品使用一個漢字的大小。</p>
-      <p its-locale-filter-list="en" lang="en">
-        Book title mark A (wavy low line) is positioned to the bottom of the marked characters in horizontal writing mode, and to the left of the marked characters in vertical writing mode.
-      </p>
-	    <p its-locale-filter-list="zh-hans" lang="zh-hans">甲式书名号（波浪线﹏）横排时标注于文字底部，直排时标注于文字左侧。</p>
-	    <p its-locale-filter-list="zh-hant" lang="zh-hant">甲式書名號（波浪線﹏）橫排時標注於文字底部，直排時標注於文字左側。</p>
-	    <p its-locale-filter-list="en" lang="en">Proper noun marks are positioned to the bottom of the marked characters in horizontal writing mode, and to the left of the marked characters in vertical writing mode.</p>
-			<p its-locale-filter-list="zh-hans" lang="zh-hans">专名号横排时标注于文字底部，直排时标注于文字左侧。</p>
-			<p its-locale-filter-list="zh-hant" lang="zh-hant">專名號橫排時標注於文字底部，直排時標注於文字左側。</p>
-			<p its-locale-filter-list="en" lang="en">Emphasis dots are positioned to the bottom of the marked characters in horizontal writing mode, and to the right of the marked characters in vertical writing mode.</p>
-			<p its-locale-filter-list="zh-hans" lang="zh-hans">着重号横排时标注于文字底部，直排时标注于文字右侧。</p>
-			<p its-locale-filter-list="zh-hant" lang="zh-hant">著重號橫排時標注於文字底部，直排時標注於文字右側。</p>
-</section>
 
 <section id="h_phrase">
   <h3>
@@ -1118,6 +1046,35 @@ var respecConfig = {
     <span its-locale-filter-list="zh-hans" lang="zh-hans">短语与章节边界</span>
     <span its-locale-filter-list="zh-hant" lang="zh-hant">短語與章節邊界</span>
   </h3>
+
+  <!-- oldid -->
+<span id="line_composition_rules_for_punctuation_marks"></span>
+
+<p its-locale-filter-list="en" lang="en">The usage of Chinese punctuation marks differs across different regions. One major difference is how the character face is handled and positioned relative to the character frame. Punctuation marks are usually center-aligned in the character frame in Taiwan and Hong Kong, while punctuation marks are positioned in the corner of the character frame on the side closest to the preceding text in the Chinese Mainland. The differences and the correct way to layout punctuation marks in different areas will be introduced in detail later.</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">中文标点符号的排版在各地区有不同的处理方式，其中较显著的差异是其字面分布——台湾、香港多使用符号居中的字形样式，而中国大陆多使用符号尾随受注文字端的字形样式，并依直、横排有不同的处理。下文将详述各地中文标点的异同及准确的配置方式。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">中文標點符號的排版在各地區有不同的處理方式，其中較顯著的差異係其字面分布——台灣、香港多使用符號居中的字形樣式，而中國大陸多使用符號尾隨受注文字端的字形樣式，並依直、橫排有不同的處理。下文將詳述各地中文標點的異同及準確的配置方式。</p>
+<p its-locale-filter-list="en" lang="en">Major typesetting differences between Traditional Chinese and Simplified Chinese include the positioning of punctuation and terminological variations. (See more at [[[#major_differences_between_horizontal_and_vertical_writing_modes]]]). </p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">在繁、简中文排版中，标点符号于字面上的位置与形状差异为二者主要的分歧点（详见[[[#major_differences_between_horizontal_and_vertical_writing_modes]]]节）。进行版式配置时，需要多加留意。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">在繁、簡中文排版中，標點符號於字面上的位置與形狀差異為二者主要的分歧點（詳見[[[#major_differences_between_horizontal_and_vertical_writing_modes]]]節）。進行版式配置時，需要多加留意。</p>
+
+<div class="note" id="n020">
+  <p its-locale-filter-list="en" lang="en">CJKV punctuation marks use different glyphs which are visually distinct between languages. Unicode currently does not distinguish each of them with unique codepoints. Usually, we use typefaces corresponding to the locale of the written text or have the layout engines adjust the punctuation marks according to the languages automatically.</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">中日韩越意音文字标点符号有地区上的字形与形态差异，但Unicode并未对其区分码位，标点多有共用。通常，排版时使用相应的字体进行配置，或由排版引擎自动调适。</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">中日韓越意音文字標點符號有地區上的字形與形態差異，但Unicode並未對其區分碼位，標點多有共用。通常，排版時使用相應的字體進行配置，或由排版引擎自動調適。</p>
+</div>
+
+
+<p its-locale-filter-list="en" lang="en">Chinese punctuation marks are mainly divided into <a href="#term.pause-or-stop-punctuation-marks" class="termref">pause or stop punctuation marks</a> and <a href="#term.indication-punctuation-marks" class="termref">indicator punctuation marks</a>. Pause or stop punctuation marks are used to indicate pauses or the end of a sentence. Some of the pause or stop punctuation marks appear within a sentence, such as secondary commas, commas, semicolons, colons, etc., while others appear at the end of a sentence, such as periods, question marks and exclamation marks.</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">中文标点符号主要分为<a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>和<a href="#term.indication-punctuation-marks" class="termref">标号</a>。点号相对于标号，用于表示语句的停顿或暂停。分为句内点号，如顿号、逗号、分号、冒号等；以及句末点号，如句号、问号、感叹号等。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">中文標點符號主要分爲<a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>和<a href="#term.indication-punctuation-marks" class="termref">標號</a>。點號相對於標號，用於表示語句的停頓或暫停。分為句內點號，如頓號、逗號、分號、冒號等；以及句末點號，如句號、問號、驚嘆號等。</p>
+
+<p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses, two-em dashes, ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于点号，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於點號，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
+
+<p its-locale-filter-list="en" lang="en">The content of the following section is mainly based on the content of <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) issued in Mainland China, as well as the <cite>Punctuation Guidance (2008 revised edition)</cite> issued by the Ministry of Education in Taiwan. The former is a recommended national standard while the latter is not mandatory for general publications but mainly used to regulate education materials like textbooks.</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">本节主要基于中国大陆的《标点符号用法》（GB/T 15834—2011）及台湾教育部的《重订标点符号手册》（2008年修订版）。前者属推荐标准，后者主要用于规范教科书等教育书籍，对一般出版品不具强制性。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">本節主要基於中國大陸的《標點符號用法》（GB/T 15834—2011）及台灣教育部的《重訂標點符號手冊》（2008年修訂版）。前者屬推薦標準，後者主要用於規範教科書等教育書籍，對一般出版品不具強制性。</p>
 
     <!-- oldid -->
     <span id="categories_and_usage_of_punctuation_marks"></span>
@@ -1196,6 +1153,10 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or add new content to the context, appearing as a horizontally and vertically centered line, and have a width of 2&nbsp;em. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] characters are also often used.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">破折号表示语气或声音的延续、语意的转换或行文的补充。呈现上为一条在水平和垂直方向均位于字面正中的直线，占两个汉字空间。推荐使用占两个汉字宽度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用两个连续的<span class="uname" translate="no">U+2014 EM DASH</span> [—]来实现。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">破折號表示語氣或聲音的延續、語意的轉換或行文的補充。呈現上為一條在水平和垂直方向均位於字面正中的直線，占兩個漢字空間。推薦使用占兩個漢字寬度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用兩個連續的<span class="uname" translate="no">U+2014 EM DASH</span> [—]來實現。</p>
+
+            <p its-locale-filter-list="en" lang="en">Two-em dashes are not supposed to be separated from one line to the next.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">破折号不得以适配分行之由断开或拆至两行。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">破折號不得以適配分行之由斷開或拆至兩行。</p>
           </li>
           <li id="id83">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Ellipses.</span> </p>
@@ -1500,10 +1461,12 @@ var respecConfig = {
   </h3>
 
 <p its-locale-filter-list="en" lang="en">Ellipses are used to indicate a truncation of text, an unfinished sentence or a break in speech. An ellipsis in Chinese consists of six dots, takes up the space of two Hanzi characters, and is horizontally and vertically centered within its character frame. This is normally achieved using two <span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS</span> characters, side-by-side.</p>
-
 <p its-locale-filter-list="zh-hans" lang="zh-hans">省略号又作删节号，表示节略原文、语句未完或语气的不连续。删节号呈现上占两个汉字空间、包含六个省略点且在水平和垂直方向均位于字面正中，通常使用两个连续的<span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS […]</span>来实现。</p>
-
 <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">刪節號又作省略號，表示節略原文、語句未完或語氣的不連續。刪節號呈現上佔兩個漢字空間、包含六個居中的刪節點且在水平和垂直方向均位於字面正中，通常使用兩個連續的<span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS […]</span>來實現。</p>
+
+<p its-locale-filter-list="en" lang="en">Ellipses are not supposed to be separated from one line to the next.</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">省略号不得以适配分行之由断开或拆至两行。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">刪節號不得以適配分行之由斷開或拆至兩行。</p>
 
 <div class="note" id="u22ef">
   <p its-locale-filter-list="en" lang="en">Chapter 6.2 of v14 of the Unicode Standard suggests using <span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯] for ellipses.</p>
@@ -1515,9 +1478,6 @@ var respecConfig = {
   <p its-locale-filter-list="zh-hant" lang="zh-hant">此符號配合適當的轉向與取代機制，在顯示上無論直橫排，刪節點皆居中，更符合排版需求。</p>
 </div>
 
-<p its-locale-filter-list="en" lang="en">When two <span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS</span> [<span lang="zh">…</span>] or <span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯] characters are used together for ellipsis, they take up the space of two Hanzi characters, are horizontally and vertically centered within their character frames, and consist of six dots.</p>
-<p its-locale-filter-list="zh-hans" lang="zh-hans">省略号使用连续两个<span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS</span> […]或<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]，占两个汉字空间、包含六个居中省略点[……]。</p>
-<p its-locale-filter-list="zh-hant" lang="zh-hant">刪節號使用連續兩個<span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS</span> […]或<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]，佔二個漢字空間、包含居中六個刪節點[……]。</p>
 <p its-locale-filter-list="en" lang="en">According to section 5.1.5 of the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011), when two ellipses are used together, they should be four characters wide and occupy an independent line.</p>
 <p its-locale-filter-list="zh-hans" lang="zh-hans">《标点符号用法》（GB/T 15834—2011）5.1.5节还规定，两个省略号／删节号连用时，占四个汉字位置并须单独占一行。</p>
 <p its-locale-filter-list="zh-hant" lang="zh-hant">《標點符號用法》（GB/T 15834—2011）5.1.5節還規定，兩個刪節號／省略號連用時，佔四個漢字位置並須單獨佔一行。</p>

--- a/indexNEW.html
+++ b/indexNEW.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Requirements for Chinese Text Layout - 中文排版需求</title>
 
-<link rel="stylesheet" href="./local.css" />
-<link rel="stylesheet" href="./print.css" />
+<link rel="stylesheet" href="./local.css">
+<link rel="stylesheet" href="./print.css">
 
 <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
 <script defer src="./built/script.js"></script>
@@ -60,7 +60,7 @@ var respecConfig = {
 </head>
 
 <body>
-<h1 class="title p-name" id="title">Requirements for Chinese Text Layout<br/><span lang="zh">中文排版需求</span></h1>
+<h1 class="title p-name" id="title">Requirements for Chinese Text Layout<br><span lang="zh">中文排版需求</span></h1>
 <section id="abstract">
   <p its-locale-filter-list="en" lang="en">This document summarizes text composition requirements in the Chinese writing system. One of the goals of the task force is to describe issues for Chinese layout, another is to describe correspondences with existing standards (such as Unicode), as well as to encourage vendors to implement relevant features correctly.</p>
   <p its-locale-filter-list="zh-hans" lang="zh-hans">本文整理了中文（汉字）书写系统于排版上的需求。一方面说明需求事项以明确描述中文排版之需求与问题；另一方面也提出与既有标准（如Unicode）的对应，冀求本文能更有效地促进实现。</p>
@@ -788,21 +788,6 @@ var respecConfig = {
 
  <!-- </section>-->
 
-    <section id="han_characters">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Han Characters</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">汉字</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">漢字</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">Han characters have square <a href="#term.character-frame" class="termref">character frames</a> of equal dimensions. Aligned with the vertical and horizontal center of the character frame, there is a smaller box called the <a href="#term.character-face" class="termref">character face</a>, which contains the actual symbol. (There should be some space left between the character face and the character frame).</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字有着正方形的<a href="#term.character-frame" class="termref">文字外框</a>。文字外框的正中央，有着比文字外框小的<a href="#term.character-face" class="termref">字面</a>（反过来说，字面的上下左右与文字外框之间有若干空白。根据不同的字面设计，空白的大小会有所不同）。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字有著正方形的<a href="#term.character-frame" class="termref">文字外框</a>。文字外框的正中央，有著比文字外框小的<a href="#term.character-face" class="termref">字面</a>（反過來說，字面的上下左右與文字外框之間有若干空白。根據不同的字面設計，空白的大小會有所不同）。</p>
-      <p its-locale-filter-list="en" lang="en">Character size is measured by the size of the character frame. <dfn id="def_characterAdvance">Character advance</dfn> is a term used to describe the advance width of the character frame of a character, which should be the same as the width of the character.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">文字尺寸则为文字外框的尺寸。此外，字幅则是依照文字排列方向的文字外框大小，为文字的宽度。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">文字尺寸則為文字外框的尺寸。此外，字幅則是依照文字排列方向的文字外框大小，為文字的寬度。</p>
-    </section>
-
 
 </section>
 
@@ -877,8 +862,8 @@ var respecConfig = {
 <section id="h_units">
   <h2>
     <span its-locale-filter-list="en" lang="en">Typographic units</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">排版单位</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">排版單位</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">排版单元</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">排版單元</span>
   </h2>
 
 
@@ -897,12 +882,15 @@ var respecConfig = {
       <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版所使用的文字和基本原則</span>
     </h3>
 -->
-    <section id="characters_used_in_chinese_composition">
+    <!-- <section id="characters_used_in_chinese_composition">
       <h4>
         <span its-locale-filter-list="en" lang="en">Characters used for Chinese Composition</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版所使用的文字</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版所使用的文字</span>
-      </h4>
+      </h4> -->
+
+    <!-- oldid -->
+    <span id="characters_used_in_chinese_composition"></span>
 
       <p its-locale-filter-list="en" lang="en">The majority of the text used in Chinese composition consists of Han characters (Hanzi).</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版主要使用的文字为汉字。</p>
@@ -922,15 +910,16 @@ var respecConfig = {
         <p its-locale-filter-list="zh-hans" lang="zh-hans">一个简体字可能对应多个繁体字，如简体字“<span lang="zh-hans">发</span>”，其相应的繁体字可能为“<span lang="zh-hant">發</span>”或“<span lang="zh-hant">髮</span>”；一个繁体汉字对应多个简体汉字的情况与前者相比数量极少但仍需注意，如繁体字“<span lang="zh-hant">乾</span>”可能对应简体字“<span lang="zh-hans">干</span>”或“<span lang="zh-hans">乾</span>”。繁简汉字的对应关系具体应由上下文决定。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">一個簡體字可能對應多個繁體字，如簡體字「<span lang="zh-hans">发</span>」，其相應的繁體字可能為「<span lang="zh-hant">發</span>」或「<span lang="zh-hant">髮</span>」；一個繁體漢字對應多個簡體漢字的情況與前者相比數量極少但仍需注意，如繁體字「<span lang="zh-hant">乾</span>」可能對應簡體字「<span lang="zh-hans">干</span>」或「<span lang="zh-hans">乾</span>」。繁簡漢字的對應關係具體應由上下文決定。</p>
       </div>
-    </section>
 
-<section id="chinese_and_western_mixed_text_composition">
+<!-- <section id="chinese_and_western_mixed_text_composition">
   <h3>
     <span its-locale-filter-list="en" lang="en">Composition of Chinese and Western Mixed Texts</span>
     <span its-locale-filter-list="zh-hans" lang="zh-hans">中、西文混排处理</span>
     <span its-locale-filter-list="zh-hant" lang="zh-hant">中、西文混排處理</span>
-  </h3>
+  </h3> -->
 
+    <!-- oldid -->
+    <span id="chinese_and_western_mixed_text_composition"></span>
 
     <p its-locale-filter-list="en" lang="en">There are many examples in Chinese text where Western text, such as Latin letters, Greek letters, or European numerals, are found alongside Han characters. The following are just a few examples:</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版中，汉字与拉丁字母、希腊字母或阿拉伯数字等西文混排的状况经常出现，以下列举部分范例。</p>
@@ -985,85 +974,6 @@ var respecConfig = {
     </h4>
   </section> -->
 
-  <section id="handling_western_text_in_chinese_text_using_proportional_western_fonts">
-    <h4>
-          <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
-          <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
-  </h4>
-
-        <p its-locale-filter-list="en" lang="en">The following provides composition rules for handling Western alphas and European numerals in horizontal writing mode or for situations in vertical writing mode where the words/phrases of Western alphas or European numerals are rotated 90 degrees clockwise:</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">横排中混排的西文字母、阿拉伯数字，及直排中将文字采顺时针旋转90°配置的西文字母、阿拉伯数字，其配置方式如下：</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排中混排的西文字母、阿拉伯數字，及直排中將文字採順時針旋轉90度配置的西文字母、阿拉伯數字，其配置方式如下：</p>
-        <ol>
-          <li id="id114">
-            <p its-locale-filter-list="en" lang="en">A sequence of Western characters in a Western word should not break across a line-break, except where hyphenation is allowed.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">西文单字词在可使用连字符处之外，不得分隔为两行。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">西文單字詞在可使用連字符處之外，不得分隔為兩行。</p>
-          </li>
-          <li id="id115">
-            <p its-locale-filter-list="en" lang="en" class="checkme">Tracking or spacing between a Han character and an alphanumeric is up to 1/4&nbsp;em.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字之间，原则上使用不多于四分之一个汉字宽的字距或空白。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字之間，原則上使用不多於四分之一個漢字寬的字距或空白。</p>
-          </li>
-          <li id="id116">
-            <p its-locale-filter-list="en" lang="en">Justified text alignment is an important feature of Chinese composition. It is harder to align text as expected when a line contains Western characters. Typically, spacing or tracking is applied equally across the line, but such adjustments are only applied between Han characters, or between a Han character and a Western character. The spacing is not equally distributed between characters in Western words and/or European numerals.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">由于中文排版强调行首与行尾对齐，当行内包含西文时，较难对齐，这时多使用均排的方式处理。均排时，各西文词组间、阿拉伯数字间的空格，以及西文字母与阿拉伯数字之间不使用均排，仅调整汉字、汉字与西文间的字距或空白。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">由於中文排版強調行頭與行尾對齊，當行內包含西文時，較難對齊，這時多使用均排的方式處理。均排時，各西文詞組間、阿拉伯數字間之空格，以及西文字母與阿拉伯數字之間不使用均排，僅調整漢字、漢字與西文間的字距或空白。</p>
-          </li>
-        </ol>
-        <p its-locale-filter-list="en" lang="en">Exceptions are made in the following cases:</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下情况例外：</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下情況例外：</p>
-        <ol>
-          <li id="id117">
-            <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or <a href="#term.european-numerals" class="termref">European numerals</a> before the line start or after the line end are not justified.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">位于行首的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之前、位于行尾的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之后不调整字距或加入空白。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行頭的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之前、位於行尾的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之後不調整字距或加入空白。</p>
-          </li>
-          <li id="id118">
-            <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or European numerals is not adjusted before or after Chinese commas or full stops, nor after Chinese opening and before Chinese closing brackets.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">在中文点号前后、中文开始夹注符号之后、结束夹注符号之前的西文字母或阿拉伯数字，不调整字距或加入空白。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">於中文點號前後、中文開始夾注符號之後、結束夾注符號之前的西文字母或阿拉伯數字，不調整字距或加入空白。</p>
-          </li>
-        </ol>
-  </section>
-
-
-      <section id="handling_of_grid_alignment_in_chinese_and_western_mixed_text_composition">
-        <h4>
-          <span its-locale-filter-list="en" lang="en">Handling of Grid Alignment in Chinese and Western Mixed Text Composition</span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐下的中西文混排处理</span>
-          <span its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊下的中西文混排處理</span>
-        </h4>
-
-        <p its-locale-filter-list="en" lang="en">Due to the fact that each Han character is of the same width, not only should characters at the start and end of a line be aligned but it is also a requirement for characters within blocks of Han text to be aligned both vertically and horizontally, whether in vertical or horizontal writing mode. When Western alphas or European numerals are present, this principle is harder to achieve. Possible approaches are listed below:</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字各字等宽的性质，无论在直排或横排的情况下，除了行齐首尾对齐外，亦求各行间的各个汉字能够纵横对齐。若遇西文字母或阿拉伯数字采用比例字体，难以满足这项原则时，处理方式如下：</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文字母或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
-        <ol>
-          <li id="id119">
-            <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between a Han character and an alphanumeric, it is possible to use flexible spacing of up to 1/2&nbsp;em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han characters before and after a Western text span snap to the grid lines.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字间不使用四分之一汉字宽的字距，而是加入大于零、小于等于二分之一汉字宽的弹性空白，使西文所占的空间为汉字的整数倍，确保西文前后的汉字都能纵横对齐。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字間不使用四分之一漢字寬之字距，而是加入大於零、小於等於二分之一漢字寬的彈性空白，使西文所佔之空間為漢字的整數倍，確保西文前後之漢字都能縱橫對齊。</p>
-          </li>
-          <li id="id120">
-            <p its-locale-filter-list="en" lang="en">When a Western word appears at the line end and needs to be broken, rather than breaking the word at a syllable boundary per the Western convention, the word may be forced to break at the line end, in order to ensure correct alignment.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">当西文单词位于行尾必须断行时，无须遵照西文从音节断行的惯例，在行尾强制断行，以确保行尾对齐。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">當西文單詞位於行尾必須斷行時，無須遵照西文從音節斷行的慣例，於行尾強制斷行，以確保行尾對齊。</p>
-          </li>
-        </ol>
-        <div class="note" id="n039">
-          <p its-locale-filter-list="en" lang="en">When using grid alignment, it is recommended to deal with line end punctuation marks by hanging the first of them outside the type area as mentioned in section [[[#hanging_punctuation_marks_at_line_end]]]. In situations that involve consecutive punctuation marks, the second and following punctuation marks are allowed to appear at the line start.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐时，可配合[[[#hanging_punctuation_marks_at_line_end]]]节的行尾点号悬挂方式处理标点禁则，若遇两个以上连续标点时，第二个及其后之标点可令其出现于行首。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊時，可配合[[[#hanging_punctuation_marks_at_line_end]]]節的行尾點號懸掛方式處理標點禁則，若遇兩個以上連續標點時，第二個及其後之標點可令其出現於行首。</p>
-        </div>
-        <div class="note" id="n040">
-          <p its-locale-filter-list="en" lang="en">Grid alignment is adopted more often in Traditional Chinese typesetting, whereas use in Simplified Chinese is rare.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐多使用于繁体中文排版，简体中文较为少见。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊多使用於繁體中文排版，簡體中文較為少見。</p>
-        </div>
-      </section>
-
     </section>
 </section>
 
@@ -1084,7 +994,6 @@ var respecConfig = {
 <p>TBD(?)</p>
 </section> -->
 
-</section>
 
 
 
@@ -1631,8 +1540,8 @@ var respecConfig = {
 <section id="h_inline_notes">
   <h2>
     <span its-locale-filter-list="en" lang="en">Inline notes &amp; annotations</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">行内注、行间注与批注</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">行內注、行間注與批注</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">行内注与行间注</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">行內注與行間注</span>
   </h2>
 
 
@@ -2165,8 +2074,8 @@ var respecConfig = {
 <section id="h_text_decoration">
   <h2>
     <span its-locale-filter-list="en" lang="en">Text decoration &amp; other inline features</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">文本装饰与其他行内特性</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">文本裝飾與其他行內特性</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">文本标示与其他行内特性</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">文本標示與其他行內特性</span>
   </h2>
 
 <section id="handling_interlinear_punctuation">
@@ -2507,6 +2416,19 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">然而，由於港台地區的點號位於字面正中，若在橫排時使用行尾懸掛，體例可能顯得突兀、不良，故橫排時不做行尾懸掛配置；但可用於直排。</p>
       <p its-locale-filter-list="en" lang="en">In the case of a succession of punctuation marks, punctuation hanging should not be applied.</p>
     </section>
+
+    <section id="id114">
+      <h4>
+            <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
+            <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
+            <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
+    </h4>
+    
+          <p its-locale-filter-list="en" lang="en" class="checkme">Western words/phrases should not break across a line-break in horizontal writing mode or in vertical writing mode where the words/phrases are rotated 90 degrees clockwise, except where hyphenation is allowed.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">横排中混排的西文单词，及直排中将文字采顺时针旋转90°配置的西文单词，在可使用连字符处之外，不得分隔为两行。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">橫排中混排的西文單詞，及直排中將文字采順時針旋轉90°配置的西文單詞，在可使用連字符處之外，不得分隔爲兩行。</p>
+    </section>
+
 </section>
 
 
@@ -3060,7 +2982,51 @@ var respecConfig = {
 
 </section>
 
+<section id="id116">
+  <h4>
+        <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
+        <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
+        <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
+</h4>
+          <p its-locale-filter-list="en" lang="en">Justified text alignment is an important feature of Chinese composition. It is harder to align text as expected when a line contains Western characters. Typically, spacing or tracking is applied equally across the line, but such adjustments are only applied between Han characters, or between a Han character and a Western character. The spacing is not equally distributed between characters in Western words and/or European numerals.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">由于中文排版强调行首与行尾对齐，当行内包含西文时，较难对齐，这时多使用均排的方式处理。均排时，各西文词组间、阿拉伯数字间的空格，以及西文字母与阿拉伯数字之间不使用均排，仅调整汉字、汉字与西文间的字距或空白。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">由於中文排版強調行頭與行尾對齊，當行內包含西文時，較難對齊，這時多使用均排的方式處理。均排時，各西文詞組間、阿拉伯數字間之空格，以及西文字母與阿拉伯數字之間不使用均排，僅調整漢字、漢字與西文間的字距或空白。</p>
+</section>
 
+
+<section id="handling_of_grid_alignment_in_chinese_and_western_mixed_text_composition">
+  <h4>
+    <span its-locale-filter-list="en" lang="en">Handling of Grid Alignment in Chinese and Western Mixed Text Composition</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐下的中西文混排处理</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊下的中西文混排處理</span>
+  </h4>
+
+  <p its-locale-filter-list="en" lang="en">Due to the fact that each Han character is of the same width, not only should characters at the start and end of a line be aligned but it is also a requirement for characters within blocks of Han text to be aligned both vertically and horizontally, whether in vertical or horizontal writing mode. When Western alphas or European numerals are present, this principle is harder to achieve. Possible approaches are listed below:</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字各字等宽的性质，无论在直排或横排的情况下，除了行齐首尾对齐外，亦求各行间的各个汉字能够纵横对齐。若遇西文字母或阿拉伯数字采用比例字体，难以满足这项原则时，处理方式如下：</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文字母或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
+  <ol>
+    <li id="id119">
+      <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between a Han character and an alphanumeric, it is possible to use flexible spacing of up to 1/2&nbsp;em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han characters before and after a Western text span snap to the grid lines.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字间不使用四分之一汉字宽的字距，而是加入大于零、小于等于二分之一汉字宽的弹性空白，使西文所占的空间为汉字的整数倍，确保西文前后的汉字都能纵横对齐。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字間不使用四分之一漢字寬之字距，而是加入大於零、小於等於二分之一漢字寬的彈性空白，使西文所佔之空間為漢字的整數倍，確保西文前後之漢字都能縱橫對齊。</p>
+    </li>
+    <li id="id120">
+      <p its-locale-filter-list="en" lang="en">When a Western word appears at the line end and needs to be broken, rather than breaking the word at a syllable boundary per the Western convention, the word may be forced to break at the line end, in order to ensure correct alignment.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">当西文单词位于行尾必须断行时，无须遵照西文从音节断行的惯例，在行尾强制断行，以确保行尾对齐。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">當西文單詞位於行尾必須斷行時，無須遵照西文從音節斷行的慣例，於行尾強制斷行，以確保行尾對齊。</p>
+    </li>
+  </ol>
+  <div class="note" id="n039">
+    <p its-locale-filter-list="en" lang="en">When using grid alignment, it is recommended to deal with line end punctuation marks by hanging the first of them outside the type area as mentioned in section [[[#hanging_punctuation_marks_at_line_end]]]. In situations that involve consecutive punctuation marks, the second and following punctuation marks are allowed to appear at the line start.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐时，可配合[[[#hanging_punctuation_marks_at_line_end]]]节的行尾点号悬挂方式处理标点禁则，若遇两个以上连续标点时，第二个及其后之标点可令其出现于行首。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊時，可配合[[[#hanging_punctuation_marks_at_line_end]]]節的行尾點號懸掛方式處理標點禁則，若遇兩個以上連續標點時，第二個及其後之標點可令其出現於行首。</p>
+  </div>
+  <div class="note" id="n040">
+    <p its-locale-filter-list="en" lang="en">Grid alignment is adopted more often in Traditional Chinese typesetting, whereas use in Simplified Chinese is rare.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐多使用于繁体中文排版，简体中文较为少见。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊多使用於繁體中文排版，簡體中文較為少見。</p>
+  </div>
+</section>
 
 
 
@@ -3353,9 +3319,12 @@ var respecConfig = {
     <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
   </h4>
 
-  <p its-locale-filter-list="en" lang="en">In horizontal writing mode, the basic approach uses proportional fonts to represent Western alphas and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4&nbsp;em, except at the line start or end.</p>
-  <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文字母使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
-  <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文字母使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
+  <p its-locale-filter-list="en" lang="en">In horizontal writing mode, the basic approach uses proportional fonts to represent Western alphas and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character or a European numerals of up to 1/4&nbsp;em, except at the line start or end.</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文字母使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文、数字出现在行首或行尾时，则无须加入空白。</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文字母使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文、數字出現在行頭或行尾時，則毋須加入空白。</p>
+  <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or European numerals is not adjusted before or after Chinese commas or full stops, nor after Chinese opening and before Chinese closing brackets.</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">在中文点号前后、中文开始夹注符号之后、结束夹注符号之前的西文字母或阿拉伯数字，不调整字距或加入空白。</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">於中文點號前後、中文開始夾注符號之後、結束夾注符號之前的西文字母或阿拉伯數字，不調整字距或加入空白。</p>
   <div class="note" id="n036">
     <p its-locale-filter-list="en" lang="en">Another approach is to use a Western word space (<span class="uname" translate="no">U+0020 SPACE</span>), in which case the width depends on the font in use.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">或可使用西文词间空格（<span class="uname" translate="no">U+0020 SPACE</span> [ ]，其宽度随不同字体有所变化）。</p>
@@ -3381,9 +3350,26 @@ var respecConfig = {
     <span its-locale-filter-list="zh-hant" lang="zh-hant">基線、行高等</span>
   </h2>
 
-<p>
-  TBD
-</p>
+  <!-- <section id="han_characters">
+    <h4>
+      <span its-locale-filter-list="en" lang="en">Han Characters</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">汉字</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">漢字</span>
+    </h4> -->
+  
+    <!-- oldid -->
+    <span id="han_characters"></span>
+    
+    <p its-locale-filter-list="en" lang="en">Han characters have square <a href="#term.character-frame" class="termref">character frames</a> of equal dimensions. Aligned with the vertical and horizontal center of the character frame, there is a smaller box called the <a href="#term.character-face" class="termref">character face</a>, which contains the actual symbol. (There should be some space left between the character face and the character frame).</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字有着正方形的<a href="#term.character-frame" class="termref">文字外框</a>。文字外框的正中央，有着比文字外框小的<a href="#term.character-face" class="termref">字面</a>（反过来说，字面的上下左右与文字外框之间有若干空白。根据不同的字面设计，空白的大小会有所不同）。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字有著正方形的<a href="#term.character-frame" class="termref">文字外框</a>。文字外框的正中央，有著比文字外框小的<a href="#term.character-face" class="termref">字面</a>（反過來說，字面的上下左右與文字外框之間有若干空白。根據不同的字面設計，空白的大小會有所不同）。</p>
+    <p its-locale-filter-list="en" lang="en">Character size is measured by the size of the character frame. <dfn id="def_characterAdvance">Character advance</dfn> is a term used to describe the advance width of the character frame of a character, which should be the same as the width of the character.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">文字尺寸则为文字外框的尺寸。此外，字幅则是依照文字排列方向的文字外框大小，为文字的宽度。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">文字尺寸則為文字外框的尺寸。此外，字幅則是依照文字排列方向的文字外框大小，為文字的寬度。</p>
+
+    <!-- <p>
+      TBD: add more content about baseline
+    </p> -->
 
 
 </section>

--- a/indexNEW.html
+++ b/indexNEW.html
@@ -287,8 +287,8 @@ var respecConfig = {
 
 <section id="writing_modes_in_chinese_composition">
   <h4>
-  <span its-locale-filter-list="en" lang="en">Writing Modes in Chinese</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中文的文字书写方向</span>
-  <span its-locale-filter-list="zh-hant" lang="zh-hant">中文的文字書寫方向</span>
+  <span its-locale-filter-list="en" lang="en">Writing Modes in Chinese</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中文的行文模式</span>
+  <span its-locale-filter-list="zh-hant" lang="zh-hant">中文的行文模式</span>
   </h4>
 
 <!-- oldid -->

--- a/indexNEW.html
+++ b/indexNEW.html
@@ -105,7 +105,7 @@ var respecConfig = {
       <span its-locale-filter-list="zh-hans" lang="zh-hans">贡献者</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">貢獻者</span>
     </h2>
-  
+
     <p its-locale-filter-list="en" lang="en">
     Information, clarifications, and translations were provided by
     Angel LI,
@@ -119,7 +119,7 @@ var respecConfig = {
     </p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">W3C中文布局任务团成员陈慧晶、陈奕钧、董福兴、李安琪、梁海、刘庆和钱争予提供了信息和翻译。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">W3C中文布局任務團成員陳慧晶、陳奕鈞、董福興、李安琪、梁海、劉慶和錢爭予提供了信息和翻譯。</p>
-  
+
     <p its-locale-filter-list="en" lang="en">Special thanks to the following people who contributed to this document (contributors' names listed in in alphabetic order). </p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">感谢以下参与者对本文档的建议与补充（依字母及拼音顺序排列）：</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">感謝以下參與者對本文檔的建議與補充（依字母及拼音順序排列）：</p>
@@ -272,26 +272,31 @@ var respecConfig = {
 <section id="h_direction">
   <h2>
     <span its-locale-filter-list="en" lang="en">Text direction</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">tbd</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">tbd</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">文本方向</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">文本方向</span>
   </h2>
 
 
 <section id="h_writing_mode">
   <h3>
     <span its-locale-filter-list="en" lang="en">Writing mode</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">tbd</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">tbd</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">行文模式</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">行文模式</span>
   </h3>
 
 
-<!--<section id="writing_modes">
-<h3> <span its-locale-filter-list="en" lang="en">Writing Modes</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">文字书写方向</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">文字書寫方向</span> </h3>
---><section id="writing_modes_in_chinese_composition">
-<h4> <span its-locale-filter-list="en" lang="en">Writing Modes in Chinese</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中文的文字书写方向</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">中文的文字書寫方向</span> </h4>
+<section id="writing_modes_in_chinese_composition">
+  <h4>
+  <span its-locale-filter-list="en" lang="en">Writing Modes in Chinese</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中文的文字书写方向</span>
+  <span its-locale-filter-list="zh-hant" lang="zh-hant">中文的文字書寫方向</span>
+  </h4>
+
+<!-- oldid -->
+<span id="writing_modes"></span>
+
 <p its-locale-filter-list="en" lang="en">Chinese composition has two text directions, <a href="#term.vertical-writing-mode" class="termref">vertical writing mode</a> and <a href="#term.horizontal-writing-mode" class="termref">horizontal writing mode</a>. Publications from Taiwan and Hong Kong are composed in vertical writing mode or horizontal writing mode; while publications from Chinese Mainland are mostly composed in horizontal writing mode, only some are composed in vertical writing mode. </p>
-<p its-locale-filter-list="zh-hans" lang="zh-hans">中文的文字书写方向分为<a href="#term.vertical-writing-mode" class="termref">直排</a>与<a href="#term.horizontal-writing-mode" class="termref">横排</a>。其中，台湾、香港的中文出版品适用直排与横排；中国大陆的出版品则多为横排，直排书籍的案例较少。</p>
-<p its-locale-filter-list="zh-hant" lang="zh-hant">中文的文字書寫方向分為<a href="#term.vertical-writing-mode" class="termref">直排</a>與<a href="#term.horizontal-writing-mode" class="termref">橫排</a>。其中，台灣、香港的中文出版品適用直排與橫排；中國大陸的出版品則多為橫排，直排書籍的案例較少。</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">中文的文本方向分为<a href="#term.vertical-writing-mode" class="termref">直排</a>与<a href="#term.horizontal-writing-mode" class="termref">横排</a>。其中，台湾、香港的中文出版品适用直排与横排；中国大陆的出版品则多为横排，直排书籍的案例较少。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">中文的文本方向分為<a href="#term.vertical-writing-mode" class="termref">直排</a>與<a href="#term.horizontal-writing-mode" class="termref">橫排</a>。其中，台灣、香港的中文出版品適用直排與橫排；中國大陸的出版品則多為橫排，直排書籍的案例較少。</p>
 <div class="note" id="n012">
 <p its-locale-filter-list="en" lang="en">Ever since the letterpress printing period, the characters and punctuation marks used for Chinese composition have basically been designed to have a square character frame. Thus the same collection of printing types can be used in either vertical writing mode or horizontal writing mode, simply by changing the direction of text. However, some adjustments will be needed for the punctuation marks so as to match the writing direction of the characters and their composition. This is described in more detail in [[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]. </p>
 <p its-locale-filter-list="zh-hans" lang="zh-hans">中文所使用的汉字与标点符号，原则上都是正方形的文字，自活字排版时代起，无论直、横排，都能使用相同的活字排列。但部分标点符号需配合文字书写方向调整字面分布及方向，见[[[#glyphs_sizes_and_positions_in_character_faces_of_punctuation_marks]]]节之詳述。</p>
@@ -511,157 +516,84 @@ var respecConfig = {
 </ol>
 </section>
 
-
-
-
-
-
-<section id="chinese_and_western_mixed_text_composition">
-    <h3>
-      <span its-locale-filter-list="en" lang="en">Composition of Chinese and Western Mixed Texts</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">中、西文混排处理</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">中、西文混排處理</span>
-    </h3>
-
-
-      <p its-locale-filter-list="en" lang="en">There are many examples in Chinese text where Western text, such as Latin letters, Greek letters, or European numerals, are found alongside Han characters. The following are just a few examples:</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版中，汉字与拉丁字母、希腊字母或阿拉伯数字等西文混排的状况经常出现，以下列举部分范例。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版中，漢字與拉丁字母、希臘字母或阿拉伯數字等西文混排的狀況經常出現，以下列舉部分範例。</p>
-      <ol>
-        <li id="id105">
-          <p its-locale-filter-list="en" lang="en">One Western letter used as a symbol for something, such as ‘A’ or ‘B’.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">使用西文字母作为符号，如“A”“B”。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">使用西文字母作為符號，如「A」「B」。</p>
-        </li>
-        <li id="id106">
-          <p its-locale-filter-list="en" lang="en">A Western word is used in a Chinese context, such as ‘editor’.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">直接使用如“editor”的西文单词。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">直接使用如「editor」的西文單字詞。</p>
-        </li>
-        <li id="id107">
-          <p its-locale-filter-list="en" lang="en">Acronyms, such as 'DTP' or 'GDP'.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">使用组织名称、专有名词等的首字母缩略词，例如DTP、GDP。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">使用組織名稱、專有名詞等的首字母縮略詞，例如DTP、GDP。</p>
-        </li>
-        <li id="id108">
-          <p its-locale-filter-list="en" lang="en">Book titles or authors in references to Western books that use the original spelling.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">呈现西文文献等的作者名、书名等时，采用原本表记的方式呈现。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">呈現西文文獻等的作者名、書名等時，採用原本表記的方式呈現。</p>
-        </li>
-        <li id="id109">
-          <p its-locale-filter-list="en" lang="en">European numerals used to express years or other numbers, such as '1999年'.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">使用阿拉伯数字表示纪年、数量值、编号等，如“1999年”。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">使用阿拉伯數字表示紀年、數量詞、編號等，如「1999年」。</p>
-        </li>
-      </ol>
-      <p its-locale-filter-list="en" lang="en">Alphanumerics are also used in itemized lists and numbered headings, or as symbols for chemical elements or mathematical formulae. It can be seen from these examples that it is an everyday occurrence to find Western characters mixed with Han characters in Chinese composition.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">项目符号与标题编号、单位符号、元素符号、数学符号等也多有西文字母或阿拉伯数字，由此可知，日常使用上中、西文的混排非常常见。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">項目符號與標題編號、單位符號、元素符號、數學符號等也多有西文字母或阿拉伯數字，由此可知，日常使用上中、西文的混排非常常見。</p>
-      <div class="note" id="n035">
-        <p its-locale-filter-list="en" lang="en">Western numerals, sometimes called arabic, or arabic-indic numerals, are referred to as European numerals in the context of this document, unless notes indicate otherwise.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">若无特别提示，本文使用的“阿拉伯数字”皆指西方语言或欧洲形式的印度-阿拉伯数字。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">若無特別提示，本文使用之「阿拉伯數字」皆指西方語言或歐洲形式的印度－阿拉伯數字。</p>
-      </div>
-      <p its-locale-filter-list="en" lang="en">Formerly, <a href="#term.fullwidth" class="termref">fullwidth</a> ASCII characters were often used, either to make the presentation look orderly, or simply due to the poorly developed computer technologies available for text layout. Nowadays, typesetting engines allow for proportional or monospace fonts, as required, rather than forcing the user to resort to the old fullwidth blocks of Latin letters and European numerals.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">过去，由于计算机排版技术不精良，多使用“<a href="#term.fullwidth" class="termref">全角</a>ASCII字符”以达到整齐等视觉排版效果。现今在文本储存时，应避免使用该区段的拉丁字母及数字字符，交由排版引擎处理比例字体、等宽字体等显示需求。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">過去，因計算機排版技術不甚精良，多使用「<a href="#term.fullwidth" class="termref">全形</a>ASCII字元」以達整齊等視覺排版效果。現今在文本儲存時，應避免使用該區段之拉丁字母及數字字元，交由排版引擎處理比例字體、等寬字體等顯示需求。</p>
-      <p its-locale-filter-list="en" lang="en">When Western texts are mixed with Han characters, Chinese style punctuation and its common usage should be used in principle since the main text is Chinese. However, in the case of technical documents, if plenty of formulae are contained in the text, the full stop can be unified with the western-style period, <span class="uname" translate="no">U+002E FULL STOP</span> [.], and the ellipsis can be unifed with the western-style ellipsis, <span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS</span> […]. The way glyphs are positioned relative to the character frame follows the Western convention for both Simplified and Traditional text. Also in textbooks on the grammar of Western languages, which contain plenty of example sentences mixed with Chinese, the aforementioned western-style periods can be used.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">中西混排中，由于正文是中文，原则上应该使用中文标点，遵守中文标点的习惯用法。但是，涉及公式较多的科学技术中文图书，句号可以统一使用西文句号<span class="uname" translate="no">U+002E FULL STOP</span> [.]，省略号可以使用西文省略号U+2026 HORIZONTAL ELLIPSIS […]，字面分布按西文习惯；又或西文例句较多且多与中文混排的中文版西文语法教材，亦可使用前述的西文句号。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">中西混排中，由於正文是中文，原則上應該使用中文標點，遵守中文標點的習慣用法。但是，涉及公式較多的科學技術中文圖書，句號可以統一使用西文句號<span class="uname" translate="no">U+002E FULL STOP</span> [.]，刪節號可以使用西文刪節號U+2026 HORIZONTAL ELLIPSIS […]，字面分布按西文習慣；又或西文例句較多且多與中文混排的中文版西文語法教材，亦可使用前述的西文句號。</p>
-
-
-    <section id="mixed_text_composition_in_horizontal_writing_mode">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Horizontal Writing Mode</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">横排的中、西文混排配置</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">In horizontal writing mode, the basic approach uses proportional fonts to represent Western alphas and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4&nbsp;em, except at the line start or end.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文字母使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文字母使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
-      <div class="note" id="n036">
-        <p its-locale-filter-list="en" lang="en">Another approach is to use a Western word space (<span class="uname" translate="no">U+0020 SPACE</span>), in which case the width depends on the font in use.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">或可使用西文词间空格（<span class="uname" translate="no">U+0020 SPACE</span> [ ]，其宽度随不同字体有所变化）。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">或可使用西文詞間空格（<span class="uname" translate="no">U+0020 SPACE</span> [ ]，其寬度隨不同字體有所變化）。</p>
-      </div>
-    </section>
-
-
 <section id="mixed_text_composition_in_vertical_writing_mode">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Vertical Writing Mode</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">直排的中、西文混排配置</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">直排的中、西文混排配置</span>
-      </h4>
+  <h4>
+    <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Vertical Writing Mode</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">直排的中、西文混排配置</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">直排的中、西文混排配置</span>
+  </h4>
 
-      <p its-locale-filter-list="en" lang="en">For vertical writing mode, the following list describes methods of setting Western alphas and <a href="#term.european-numerals" class="termref">European numerals</a>:</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时，西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>的配置有以下三种方法：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時，西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>的配置有以下三種方法：</p>
-      <ol>
-        <li id="id110">
-          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western text with Han character width monospace fonts</span>. Western alphas or European numerals follow each other, one at a time, in the same direction and orientation as the Han characters. This arrangement is usually adopted where the text contains a single letter or digit, or an acronym (such as <abbr title="Gross Domestic Product">GDP</abbr>).</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">采用与汉字等宽的字体或全角文字，使用与汉字相同的书写方向依字母排列，无须转向。当文中的西文字母与阿拉伯数字为单独一字或为首字母缩略词时（如GDP），多使用这种方式配置。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">採用與漢字等寬之字體或全形字元，使用與漢字相同的書寫方向依字母排列，毋須轉向。當文中的西文字母與阿拉伯數字為單獨一字、或為首字母縮略詞時（如GDP），多使用這種方式配置。</p>
-          <figure id="latin-normal-orientation">
-            <img its-locale-filter-list="en" lang="en" src="images/en/latin-one-by-one.svg" alt="Example of Western alphas in normal orientation." width="123" height="181">
-            <img its-locale-filter-list="zh-hans" lang="zh-hans" src="images/zh/latin-one-by-one-Hans.svg" alt="没有转向的西文字母示例" width="123" height="181">
-            <img its-locale-filter-list="zh-hant" lang="zh-hant" src="images/zh/latin-one-by-one-Hant.svg" alt="沒有轉向的西文字母示例" width="123" height="181">
-              <figcaption>
-              <span its-locale-filter-list="en" lang="en">Example of Western alphas in normal orientation.</span>
-              <span its-locale-filter-list="zh-hans" lang="zh-hans">没有转向的西文字母示例</span>
-              <span its-locale-filter-list="zh-hant" lang="zh-hant">沒有轉向的西文字母示例</span>
-              </figcaption>
-          </figure>
-        </li>
-        <li id="id111">
-          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western text with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Western text compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western alpha or European numeral, up to a width of 1/4&nbsp;em, except at the line start or end.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">采用比例字体，将文字顺时针旋转90°配置。当文中的西文为一般单词、语句或四位数以上的阿拉伯数字时，采用此方法配置。汉字与西文字母、阿拉伯数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">採用比例字體，將文字順時針旋轉90度配置。當文中的西字為一般單字詞、語句，或阿拉伯數在四位數以上時，採用此方法配置。漢字與西文字母、阿拉伯數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
-          <figure id="latin-90-clockwise-2">
-            <img its-locale-filter-list="en" lang="en" src="images/en/latin-90-clockwise.svg" alt="Example of Western alphas rotated 90 degrees clockwise." width="124" height="188">
-            <img its-locale-filter-list="zh-hans" lang="zh-hans" src="images/zh/latin-90-clockwise-Hans.svg" alt="顺时针旋转90°的西文字母示例" width="124" height="188">
-            <img its-locale-filter-list="zh-hant" lang="zh-hant" src="images/zh/latin-90-clockwise-Hant.svg" alt="順時針旋轉90°的西文字母示例" width="124" height="188">
-              <figcaption>
-              <span its-locale-filter-list="en" lang="en">Example of Western alphas rotated 90 degrees clockwise.</span>
-              <span its-locale-filter-list="zh-hans" lang="zh-hans">顺时针旋转90°的西文字母示例</span>
-              <span its-locale-filter-list="zh-hant" lang="zh-hant">順時針旋轉90°的西文字母示例</span>
-              </figcaption>
-          </figure>
-        </li>
-        <li id="id112">
-          <p its-locale-filter-list="en" lang="en"><span class="leadin">Setting European numerals with proportional fonts in <a href="#term.horizontal-in-vertical" class="termref">horizontal-in-vertical orientation</a>.</span> This style is usually adopted when dealing with a two to three digit number whose width is equal to the default line advance or slightly wider (within an acceptable range).</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">阿拉伯数字使用比例字体，以<a href="#term.horizontal-in-vertical" class="termref">纵中横排</a>（保持正常方向，横排）方式配置。主要应用于两至三位数的阿拉伯数字，其宽度与行幅相当，或稍微切出行幅。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">阿拉伯數字使用比例字體，以<a href="#term.horizontal-in-vertical" class="termref">縱中橫排</a>（保持正常方向，橫排）方式配置。主要應用於二至三位數的阿拉伯數字，其寬度與行幅相當，或稍微切出行幅。</p>
-        </li>
-      </ol>
-      <div class="note" id="n037">
-        <p its-locale-filter-list="en" lang="en">Han numerals are usually used in vertical writing mode, however, in recent years it is becoming more common to see fullwidth European numerals and proportional numerals set as <a href="#term.horizontal-in-vertical" class="termref">horizontal-in-vertical</a>.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时多使用汉字数字，然而近年使用阿拉伯数字的情况渐有增长，<a href="#term.horizontal-in-vertical" class="termref">纵中横排</a>亦颇为常见。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時多使用漢字數字，然而近年使用阿拉伯數字的情況漸有增長，<a href="#term.horizontal-in-vertical" class="termref">縱中橫排</a>亦頗為常見。</p>
-      </div>
-      <div class="note" id="n038">
-        <p its-locale-filter-list="en" lang="en">Quotation marks are usually not used in vertical writing mode (corner brackets are used instead). However, when quoting Western text, quotation marks are sometimes used to match Western style. In this case, the orientation of the quotation marks must follow the quoted Western text (rotated 90° clockwise).</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时通常不使用弯引号，但在直排中引用西文内容时，可采用与西文样式更匹配的弯引号。该情况下，弯引号的书写方向需跟随被引用的西文内容转向。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時通常不使用彎引號，但在直排中引用西文內容時，可採用與西文樣式更匹配的彎引號。該情況下，彎引號的書寫方向需跟隨被引用的西文內容轉向。</p>
-      </div>
-    </section>
-</section>
+  <p its-locale-filter-list="en" lang="en">For vertical writing mode, the following list describes methods of setting Western alphas and <a href="#term.european-numerals" class="termref">European numerals</a>:</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时，西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>的配置有以下三种方法：</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時，西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>的配置有以下三種方法：</p>
+  <ol>
+    <li id="id110">
+      <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western text with Han character width monospace fonts</span>. Western alphas or European numerals follow each other, one at a time, in the same direction and orientation as the Han characters. This arrangement is usually adopted where the text contains a single letter or digit, or an acronym (such as <abbr title="Gross Domestic Product">GDP</abbr>).</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">采用与汉字等宽的字体或全角文字，使用与汉字相同的书写方向依字母排列，无须转向。当文中的西文字母与阿拉伯数字为单独一字或为首字母缩略词时（如GDP），多使用这种方式配置。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">採用與漢字等寬之字體或全形字元，使用與漢字相同的書寫方向依字母排列，毋須轉向。當文中的西文字母與阿拉伯數字為單獨一字、或為首字母縮略詞時（如GDP），多使用這種方式配置。</p>
+      <figure id="latin-normal-orientation">
+        <img its-locale-filter-list="en" lang="en" src="images/en/latin-one-by-one.svg" alt="Example of Western alphas in normal orientation." width="123" height="181">
+        <img its-locale-filter-list="zh-hans" lang="zh-hans" src="images/zh/latin-one-by-one-Hans.svg" alt="没有转向的西文字母示例" width="123" height="181">
+        <img its-locale-filter-list="zh-hant" lang="zh-hant" src="images/zh/latin-one-by-one-Hant.svg" alt="沒有轉向的西文字母示例" width="123" height="181">
+          <figcaption>
+          <span its-locale-filter-list="en" lang="en">Example of Western alphas in normal orientation.</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">没有转向的西文字母示例</span>
+          <span its-locale-filter-list="zh-hant" lang="zh-hant">沒有轉向的西文字母示例</span>
+          </figcaption>
+      </figure>
+    </li>
+    <li id="id111">
+      <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Setting Western text with proportional fonts, rotated 90 degrees clockwise.</span> This approach is usually adopted where Western text compose a word or sentence. There is tracking or spacing between a Han character and an adjacent Western alpha or European numeral, up to a width of 1/4&nbsp;em, except at the line start or end.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">采用比例字体，将文字顺时针旋转90°配置。当文中的西文为一般单词、语句或四位数以上的阿拉伯数字时，采用此方法配置。汉字与西文字母、阿拉伯数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">採用比例字體，將文字順時針旋轉90度配置。當文中的西字為一般單字詞、語句，或阿拉伯數在四位數以上時，採用此方法配置。漢字與西文字母、阿拉伯數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
+      <figure id="latin-90-clockwise-2">
+        <img its-locale-filter-list="en" lang="en" src="images/en/latin-90-clockwise.svg" alt="Example of Western alphas rotated 90 degrees clockwise." width="124" height="188">
+        <img its-locale-filter-list="zh-hans" lang="zh-hans" src="images/zh/latin-90-clockwise-Hans.svg" alt="顺时针旋转90°的西文字母示例" width="124" height="188">
+        <img its-locale-filter-list="zh-hant" lang="zh-hant" src="images/zh/latin-90-clockwise-Hant.svg" alt="順時針旋轉90°的西文字母示例" width="124" height="188">
+          <figcaption>
+          <span its-locale-filter-list="en" lang="en">Example of Western alphas rotated 90 degrees clockwise.</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">顺时针旋转90°的西文字母示例</span>
+          <span its-locale-filter-list="zh-hant" lang="zh-hant">順時針旋轉90°的西文字母示例</span>
+          </figcaption>
+      </figure>
+    </li>
+    <li id="id112">
+      <p its-locale-filter-list="en" lang="en"><span class="leadin">Setting European numerals with proportional fonts in <a href="#term.horizontal-in-vertical" class="termref">horizontal-in-vertical orientation</a>.</span> This style is usually adopted when dealing with a two to three digit number whose width is equal to the default line advance or slightly wider (within an acceptable range).</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">阿拉伯数字使用比例字体，以<a href="#term.horizontal-in-vertical" class="termref">纵中横排</a>（保持正常方向，横排）方式配置。主要应用于两至三位数的阿拉伯数字，其宽度与行幅相当，或稍微切出行幅。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">阿拉伯數字使用比例字體，以<a href="#term.horizontal-in-vertical" class="termref">縱中橫排</a>（保持正常方向，橫排）方式配置。主要應用於二至三位數的阿拉伯數字，其寬度與行幅相當，或稍微切出行幅。</p>
+    </li>
+  </ol>
+  <div class="note" id="n037">
+    <p its-locale-filter-list="en" lang="en">Han numerals are usually used in vertical writing mode, however, in recent years it is becoming more common to see fullwidth European numerals and proportional numerals set as <a href="#term.horizontal-in-vertical" class="termref">horizontal-in-vertical</a>.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时多使用汉字数字，然而近年使用阿拉伯数字的情况渐有增长，<a href="#term.horizontal-in-vertical" class="termref">纵中横排</a>亦颇为常见。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時多使用漢字數字，然而近年使用阿拉伯數字的情況漸有增長，<a href="#term.horizontal-in-vertical" class="termref">縱中橫排</a>亦頗為常見。</p>
+  </div>
+  <div class="note" id="n038">
+    <p its-locale-filter-list="en" lang="en">Quotation marks are usually not used in vertical writing mode (corner brackets are used instead). However, when quoting Western text, quotation marks are sometimes used to match Western style. In this case, the orientation of the quotation marks must follow the quoted Western text (rotated 90° clockwise).</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时通常不使用弯引号，但在直排中引用西文内容时，可采用与西文样式更匹配的弯引号。该情况下，弯引号的书写方向需跟随被引用的西文内容转向。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時通常不使用彎引號，但在直排中引用西文內容時，可採用與西文樣式更匹配的彎引號。該情況下，彎引號的書寫方向需跟隨被引用的西文內容轉向。</p>
+  </div>
 </section>
 
 
 
 
 
+</section>
 
 
 
 
-<section id="h_bidi_text">
+
+
+
+
+
+<!-- <section id="h_bidi_text">
   <h3>
     <span its-locale-filter-list="en" lang="en">Bidirectional text</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">双向文本</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">雙向文本</span>
   </h3>
 
 <div class="ednote">
@@ -672,7 +604,9 @@ var respecConfig = {
 <li>Leave this as a placeholder for future reference.</li>
 </ol>
 </div>
-</section>
+</section> -->
+
+
 </section>
 
 
@@ -689,8 +623,8 @@ var respecConfig = {
 <section id="h_shaping">
   <h2>
     <span its-locale-filter-list="en" lang="en">Glyph shaping &amp; positioning</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">字形的变形与定位</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">字形的變形與定位</span>
   </h2>
 
 
@@ -698,24 +632,20 @@ var respecConfig = {
 <section id="h_fonts">
   <h3>
     <span its-locale-filter-list="en" lang="en">Fonts &amp; font styles</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">字型与字型样式</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">字型與字型樣式</span>
   </h3>
 
 
-<!--<section id="commonly_used_chinese_typefaces">
-    <h3>
-      <span its-locale-filter-list="en" lang="en">Typefaces for Chinese Text</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版常用字体</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版常用字體</span>
-    </h3>
--->
     <section id="four_commonly_used_typefaces_for_chinese_composition">
       <h4>
         <span its-locale-filter-list="en" lang="en">Four frequently-used Typefaces for Chinese Text</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版经常使用的四种字体</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版經常使用的四種字體</span>
       </h4>
+
+      <!-- oldid -->
+      <span id="commonly_used_chinese_typefaces"></span>
 
       <p its-locale-filter-list="en" lang="en">
         There are many types of typefaces used in Chinese composition, but the following four typefaces are the most important ones:
@@ -873,7 +803,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">文字尺寸則為文字外框的尺寸。此外，字幅則是依照文字排列方向的文字外框大小，為文字的寬度。</p>
     </section>
 
-  
+
 </section>
 
 
@@ -886,19 +816,303 @@ var respecConfig = {
 
 
 
-<section id="h_context">
+<!-- <section id="h_context">
   <h3>
     <span its-locale-filter-list="en" lang="en">Context-based shaping &amp; positioning</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">基于上下文的字形变形与定位</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">基于上下文的字形變形與定位</span>
+  </h3>
+
+</section> -->
+
+
+
+
+
+
+
+
+
+
+
+<!-- <section id="h_letterforms">
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Letterform slopes, weights, &amp; italics</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">斜体、字重与意大利体</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">斜體、字重與意大利體</span>
+  </h3>
+
+<p>TBD(?)</p>
+</section> -->
+
+</section>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<section id="h_units">
+  <h2>
+    <span its-locale-filter-list="en" lang="en">Typographic units</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">排版单位</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">排版單位</span>
+  </h2>
+
+
+
+<section id="h_encoding">
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Characters &amp; encoding</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">字符与编码</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">字元與編碼</span>
+  </h3>
+
+<!--<section id="characters_and_the_principles_of_setting_them_for_chinese_composition">
+    <h3>
+      <span its-locale-filter-list="en" lang="en">Characters and Principles for Arranging Characters in Chinese Composition</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版所使用的文字和基本原则</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版所使用的文字和基本原則</span>
+    </h3>
+-->
+    <section id="characters_used_in_chinese_composition">
+      <h4>
+        <span its-locale-filter-list="en" lang="en">Characters used for Chinese Composition</span>
+        <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版所使用的文字</span>
+        <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版所使用的文字</span>
+      </h4>
+
+      <p its-locale-filter-list="en" lang="en">The majority of the text used in Chinese composition consists of Han characters (Hanzi).</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版主要使用的文字为汉字。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版主要使用的文字為漢字。</p>
+      <p its-locale-filter-list="en" lang="en">Chinese characters include Traditional Chinese and Simplified Chinese alternatives. The former is commonly used in Taiwan, Hong Kong and Macao while the latter is commonly used in Mainland China, Singapore and Malaysia.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">依照各地的通行标准，中文所使用的汉字主要分为繁体字与简体字。前者又称正体字、传统汉字等，主要通行于台湾、香港、澳门等地；后者又作简化字，主要通行于中国大陆、新马地区。本文依笔画多寡与部件结构为区别，分别称为繁体字与简体字。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">依照各地的通行標準，中文所使用的漢字主要分為繁體字與簡體字。前者又作正體字、傳統漢字等，主要通行於台灣、香港、澳門等地；後者又作簡化字，主要通行於中國大陸、星馬地區。本文依筆畫多寡與部件結構為區別，分別稱為繁體字與簡體字。</p>
+      <p its-locale-filter-list="en" lang="en">Different glyphs are used in different regions. One <a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point">Unicode code point</a> of a Han character may have more than one valid glyph, depending on operating system and typeface used. The focus of this document is Chinese composition and will not cover glyph variations in detail.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">不同地区所使用的字形有差异，各种字形与<a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point">Unicode码位</a>并非一一对应关系，需要依赖处理系统和字体来呈现。本文主要探究中文排版，对此不做详述。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">不同地區所使用的字形有差異，各種字形與<a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point">Unicode碼位</a>並非一一對應關係，需要依賴處理系統和字體來呈現。本文主要探究中文排版，對此不做詳述。</p>
+      <p its-locale-filter-list="en" lang="en">In addition to Han characters (Hanzi), various punctuation marks, as well as Western text such as European numerals, Latin letters and/or Greek letters, may be used in Chinese text.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版除了汉字外，也使用标点符号，也会与阿拉伯数字、拉丁文字、希腊文字等西文混排。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版除了漢字外，也使用標點符號。也會與阿拉伯數字、拉丁文字、希臘文字等西文混排。</p>
+
+      <div class="note" id="n002">
+        <p its-locale-filter-list="en" lang="en">One Simplified Chinese character may have more than one corresponding Traditional form. For example, the Simplified Chinese character <span lang="zh-hans">发</span> can be mapped to either the Traditional Chinese character <span lang="zh-hant">發</span> or <span lang="zh-hant">髮</span>. By contrast, the circumstances where one Traditional Chinese character corresponds to more than one Simplified Chinese character are fairly rare but still worth noting. For example, the Traditional Chinese character <span lang="zh-hant">乾</span> may be mapped to either the Simplified Chinese character <span lang="zh-hans">干</span> or <span lang="zh-hans">乾</span>. The mapping relationship between Traditional and Simplified Chinese is not one-to-one and particular character conversion depends on its context.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">一个简体字可能对应多个繁体字，如简体字“<span lang="zh-hans">发</span>”，其相应的繁体字可能为“<span lang="zh-hant">發</span>”或“<span lang="zh-hant">髮</span>”；一个繁体汉字对应多个简体汉字的情况与前者相比数量极少但仍需注意，如繁体字“<span lang="zh-hant">乾</span>”可能对应简体字“<span lang="zh-hans">干</span>”或“<span lang="zh-hans">乾</span>”。繁简汉字的对应关系具体应由上下文决定。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">一個簡體字可能對應多個繁體字，如簡體字「<span lang="zh-hans">发</span>」，其相應的繁體字可能為「<span lang="zh-hant">發</span>」或「<span lang="zh-hant">髮</span>」；一個繁體漢字對應多個簡體漢字的情況與前者相比數量極少但仍需注意，如繁體字「<span lang="zh-hant">乾</span>」可能對應簡體字「<span lang="zh-hans">干</span>」或「<span lang="zh-hans">乾</span>」。繁簡漢字的對應關係具體應由上下文決定。</p>
+      </div>
+    </section>
+
+<section id="chinese_and_western_mixed_text_composition">
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Composition of Chinese and Western Mixed Texts</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">中、西文混排处理</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">中、西文混排處理</span>
   </h3>
 
 
+    <p its-locale-filter-list="en" lang="en">There are many examples in Chinese text where Western text, such as Latin letters, Greek letters, or European numerals, are found alongside Han characters. The following are just a few examples:</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版中，汉字与拉丁字母、希腊字母或阿拉伯数字等西文混排的状况经常出现，以下列举部分范例。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版中，漢字與拉丁字母、希臘字母或阿拉伯數字等西文混排的狀況經常出現，以下列舉部分範例。</p>
+    <ol>
+      <li id="id105">
+        <p its-locale-filter-list="en" lang="en">One Western letter used as a symbol for something, such as ‘A’ or ‘B’.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">使用西文字母作为符号，如“A”“B”。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">使用西文字母作為符號，如「A」「B」。</p>
+      </li>
+      <li id="id106">
+        <p its-locale-filter-list="en" lang="en">A Western word is used in a Chinese context, such as ‘editor’.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">直接使用如“editor”的西文单词。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">直接使用如「editor」的西文單字詞。</p>
+      </li>
+      <li id="id107">
+        <p its-locale-filter-list="en" lang="en">Acronyms, such as 'DTP' or 'GDP'.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">使用组织名称、专有名词等的首字母缩略词，例如DTP、GDP。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">使用組織名稱、專有名詞等的首字母縮略詞，例如DTP、GDP。</p>
+      </li>
+      <li id="id108">
+        <p its-locale-filter-list="en" lang="en">Book titles or authors in references to Western books that use the original spelling.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">呈现西文文献等的作者名、书名等时，采用原本表记的方式呈现。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">呈現西文文獻等的作者名、書名等時，採用原本表記的方式呈現。</p>
+      </li>
+      <li id="id109">
+        <p its-locale-filter-list="en" lang="en">European numerals used to express years or other numbers, such as '1999年'.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">使用阿拉伯数字表示纪年、数量值、编号等，如“1999年”。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">使用阿拉伯數字表示紀年、數量詞、編號等，如「1999年」。</p>
+      </li>
+    </ol>
+    <p its-locale-filter-list="en" lang="en">Alphanumerics are also used in itemized lists and numbered headings, or as symbols for chemical elements or mathematical formulae. It can be seen from these examples that it is an everyday occurrence to find Western characters mixed with Han characters in Chinese composition.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">项目符号与标题编号、单位符号、元素符号、数学符号等也多有西文字母或阿拉伯数字，由此可知，日常使用上中、西文的混排非常常见。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">項目符號與標題編號、單位符號、元素符號、數學符號等也多有西文字母或阿拉伯數字，由此可知，日常使用上中、西文的混排非常常見。</p>
+    <div class="note" id="n035">
+      <p its-locale-filter-list="en" lang="en">Western numerals, sometimes called arabic, or arabic-indic numerals, are referred to as European numerals in the context of this document, unless notes indicate otherwise.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">若无特别提示，本文使用的“阿拉伯数字”皆指西方语言或欧洲形式的印度-阿拉伯数字。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">若無特別提示，本文使用之「阿拉伯數字」皆指西方語言或歐洲形式的印度－阿拉伯數字。</p>
+    </div>
+    <p its-locale-filter-list="en" lang="en">Formerly, <a href="#term.fullwidth" class="termref">fullwidth</a> ASCII characters were often used, either to make the presentation look orderly, or simply due to the poorly developed computer technologies available for text layout. Nowadays, typesetting engines allow for proportional or monospace fonts, as required, rather than forcing the user to resort to the old fullwidth blocks of Latin letters and European numerals.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">过去，由于计算机排版技术不精良，多使用“<a href="#term.fullwidth" class="termref">全角</a>ASCII字符”以达到整齐等视觉排版效果。现今在文本储存时，应避免使用该区段的拉丁字母及数字字符，交由排版引擎处理比例字体、等宽字体等显示需求。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">過去，因計算機排版技術不甚精良，多使用「<a href="#term.fullwidth" class="termref">全形</a>ASCII字元」以達整齊等視覺排版效果。現今在文本儲存時，應避免使用該區段之拉丁字母及數字字元，交由排版引擎處理比例字體、等寬字體等顯示需求。</p>
+    <p its-locale-filter-list="en" lang="en">When Western texts are mixed with Han characters, Chinese style punctuation and its common usage should be used in principle since the main text is Chinese. However, in the case of technical documents, if plenty of formulae are contained in the text, the full stop can be unified with the western-style period, <span class="uname" translate="no">U+002E FULL STOP</span> [.], and the ellipsis can be unifed with the western-style ellipsis, <span class="uname" translate="no">U+2026 HORIZONTAL ELLIPSIS</span> […]. The way glyphs are positioned relative to the character frame follows the Western convention for both Simplified and Traditional text. Also in textbooks on the grammar of Western languages, which contain plenty of example sentences mixed with Chinese, the aforementioned western-style periods can be used.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">中西混排中，由于正文是中文，原则上应该使用中文标点，遵守中文标点的习惯用法。但是，涉及公式较多的科学技术中文图书，句号可以统一使用西文句号<span class="uname" translate="no">U+002E FULL STOP</span> [.]，省略号可以使用西文省略号U+2026 HORIZONTAL ELLIPSIS […]，字面分布按西文习惯；又或西文例句较多且多与中文混排的中文版西文语法教材，亦可使用前述的西文句号。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">中西混排中，由於正文是中文，原則上應該使用中文標點，遵守中文標點的習慣用法。但是，涉及公式較多的科學技術中文圖書，句號可以統一使用西文句號<span class="uname" translate="no">U+002E FULL STOP</span> [.]，刪節號可以使用西文刪節號U+2026 HORIZONTAL ELLIPSIS […]，字面分布按西文習慣；又或西文例句較多且多與中文混排的中文版西文語法教材，亦可使用前述的西文句號。</p>
 
-<ins><p>See also the section [[[#h_inline_notes]]], starting from [[[#overview_of_positioning_of_interlinear_annotations]]].</p></ins>
+  <!-- <section>
+    <h4>
+      <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Horizontal Writing Mode</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">横排的中、西文混排配置</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
+    </h4>
+  </section> -->
+
+  <section id="handling_western_text_in_chinese_text_using_proportional_western_fonts">
+    <h4>
+          <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
+          <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
+  </h4>
+
+        <p its-locale-filter-list="en" lang="en">The following provides composition rules for handling Western alphas and European numerals in horizontal writing mode or for situations in vertical writing mode where the words/phrases of Western alphas or European numerals are rotated 90 degrees clockwise:</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">横排中混排的西文字母、阿拉伯数字，及直排中将文字采顺时针旋转90°配置的西文字母、阿拉伯数字，其配置方式如下：</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排中混排的西文字母、阿拉伯數字，及直排中將文字採順時針旋轉90度配置的西文字母、阿拉伯數字，其配置方式如下：</p>
+        <ol>
+          <li id="id114">
+            <p its-locale-filter-list="en" lang="en">A sequence of Western characters in a Western word should not break across a line-break, except where hyphenation is allowed.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">西文单字词在可使用连字符处之外，不得分隔为两行。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">西文單字詞在可使用連字符處之外，不得分隔為兩行。</p>
+          </li>
+          <li id="id115">
+            <p its-locale-filter-list="en" lang="en" class="checkme">Tracking or spacing between a Han character and an alphanumeric is up to 1/4&nbsp;em.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字之间，原则上使用不多于四分之一个汉字宽的字距或空白。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字之間，原則上使用不多於四分之一個漢字寬的字距或空白。</p>
+          </li>
+          <li id="id116">
+            <p its-locale-filter-list="en" lang="en">Justified text alignment is an important feature of Chinese composition. It is harder to align text as expected when a line contains Western characters. Typically, spacing or tracking is applied equally across the line, but such adjustments are only applied between Han characters, or between a Han character and a Western character. The spacing is not equally distributed between characters in Western words and/or European numerals.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">由于中文排版强调行首与行尾对齐，当行内包含西文时，较难对齐，这时多使用均排的方式处理。均排时，各西文词组间、阿拉伯数字间的空格，以及西文字母与阿拉伯数字之间不使用均排，仅调整汉字、汉字与西文间的字距或空白。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">由於中文排版強調行頭與行尾對齊，當行內包含西文時，較難對齊，這時多使用均排的方式處理。均排時，各西文詞組間、阿拉伯數字間之空格，以及西文字母與阿拉伯數字之間不使用均排，僅調整漢字、漢字與西文間的字距或空白。</p>
+          </li>
+        </ol>
+        <p its-locale-filter-list="en" lang="en">Exceptions are made in the following cases:</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">以下情况例外：</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">以下情況例外：</p>
+        <ol>
+          <li id="id117">
+            <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or <a href="#term.european-numerals" class="termref">European numerals</a> before the line start or after the line end are not justified.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">位于行首的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之前、位于行尾的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之后不调整字距或加入空白。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行頭的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之前、位於行尾的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之後不調整字距或加入空白。</p>
+          </li>
+          <li id="id118">
+            <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or European numerals is not adjusted before or after Chinese commas or full stops, nor after Chinese opening and before Chinese closing brackets.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">在中文点号前后、中文开始夹注符号之后、结束夹注符号之前的西文字母或阿拉伯数字，不调整字距或加入空白。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">於中文點號前後、中文開始夾注符號之後、結束夾注符號之前的西文字母或阿拉伯數字，不調整字距或加入空白。</p>
+          </li>
+        </ol>
+  </section>
 
 
-<section id="line_composition_rules_for_punctuation_marks">
+      <section id="handling_of_grid_alignment_in_chinese_and_western_mixed_text_composition">
+        <h4>
+          <span its-locale-filter-list="en" lang="en">Handling of Grid Alignment in Chinese and Western Mixed Text Composition</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐下的中西文混排处理</span>
+          <span its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊下的中西文混排處理</span>
+        </h4>
+
+        <p its-locale-filter-list="en" lang="en">Due to the fact that each Han character is of the same width, not only should characters at the start and end of a line be aligned but it is also a requirement for characters within blocks of Han text to be aligned both vertically and horizontally, whether in vertical or horizontal writing mode. When Western alphas or European numerals are present, this principle is harder to achieve. Possible approaches are listed below:</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字各字等宽的性质，无论在直排或横排的情况下，除了行齐首尾对齐外，亦求各行间的各个汉字能够纵横对齐。若遇西文字母或阿拉伯数字采用比例字体，难以满足这项原则时，处理方式如下：</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文字母或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
+        <ol>
+          <li id="id119">
+            <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between a Han character and an alphanumeric, it is possible to use flexible spacing of up to 1/2&nbsp;em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han characters before and after a Western text span snap to the grid lines.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字间不使用四分之一汉字宽的字距，而是加入大于零、小于等于二分之一汉字宽的弹性空白，使西文所占的空间为汉字的整数倍，确保西文前后的汉字都能纵横对齐。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字間不使用四分之一漢字寬之字距，而是加入大於零、小於等於二分之一漢字寬的彈性空白，使西文所佔之空間為漢字的整數倍，確保西文前後之漢字都能縱橫對齊。</p>
+          </li>
+          <li id="id120">
+            <p its-locale-filter-list="en" lang="en">When a Western word appears at the line end and needs to be broken, rather than breaking the word at a syllable boundary per the Western convention, the word may be forced to break at the line end, in order to ensure correct alignment.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">当西文单词位于行尾必须断行时，无须遵照西文从音节断行的惯例，在行尾强制断行，以确保行尾对齐。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">當西文單詞位於行尾必須斷行時，無須遵照西文從音節斷行的慣例，於行尾強制斷行，以確保行尾對齊。</p>
+          </li>
+        </ol>
+        <div class="note" id="n039">
+          <p its-locale-filter-list="en" lang="en">When using grid alignment, it is recommended to deal with line end punctuation marks by hanging the first of them outside the type area as mentioned in section [[[#hanging_punctuation_marks_at_line_end]]]. In situations that involve consecutive punctuation marks, the second and following punctuation marks are allowed to appear at the line start.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐时，可配合[[[#hanging_punctuation_marks_at_line_end]]]节的行尾点号悬挂方式处理标点禁则，若遇两个以上连续标点时，第二个及其后之标点可令其出现于行首。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊時，可配合[[[#hanging_punctuation_marks_at_line_end]]]節的行尾點號懸掛方式處理標點禁則，若遇兩個以上連續標點時，第二個及其後之標點可令其出現於行首。</p>
+        </div>
+        <div class="note" id="n040">
+          <p its-locale-filter-list="en" lang="en">Grid alignment is adopted more often in Traditional Chinese typesetting, whereas use in Simplified Chinese is rare.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐多使用于繁体中文排版，简体中文较为少见。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊多使用於繁體中文排版，簡體中文較為少見。</p>
+        </div>
+      </section>
+
+    </section>
+</section>
+
+
+
+
+
+
+
+
+<!-- <section id="h_segmentation">
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Grapheme/word segmentation &amp; selection</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">字素、词语的分割与选择</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">字素、詞語的分割與選擇</span>
+  </h3>
+
+<p>TBD(?)</p>
+</section> -->
+
+</section>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<section id="h_inline">
+  <h2>
+    <span its-locale-filter-list="en" lang="en">Punctuation &amp; inline features</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号与其他行内特性</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號與其他行內特性</span>
+  </h2>
+
+  <section id="line_composition_rules_for_punctuation_marks">
     <h3>
       <span its-locale-filter-list="en" lang="en">Line Composition Rules for Punctuation Marks</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号与其排版</span>
@@ -918,22 +1132,18 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant">中日韓越意音文字標點符號有地區上的字形與形態差異，但Unicode並未對其區分碼位，標點多有共用。通常，排版時使用相應的字體進行配置，或由排版引擎自動調適。</p>
     </div>
 
-    
 
+    <p its-locale-filter-list="en" lang="en">Chinese punctuation marks are mainly divided into <a href="#term.pause-or-stop-punctuation-marks" class="termref">pause or stop punctuation marks</a> and <a href="#term.indication-punctuation-marks" class="termref">indicator punctuation marks</a>. Pause or stop punctuation marks are used to indicate pauses or the end of a sentence. Some of the pause or stop punctuation marks appear within a sentence, such as secondary commas, commas, semicolons, colons, etc., while others appear at the end of a sentence, such as periods, question marks and exclamation marks.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">中文标点符号主要分为<a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>和<a href="#term.indication-punctuation-marks" class="termref">标号</a>。点号相对于标号，用于表示语句的停顿或暂停。分为句内点号，如顿号、逗号、分号、冒号等；以及句末点号，如句号、问号、感叹号等。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">中文標點符號主要分爲<a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>和<a href="#term.indication-punctuation-marks" class="termref">標號</a>。點號相對於標號，用於表示語句的停頓或暫停。分為句內點號，如頓號、逗號、分號、冒號等；以及句末點號，如句號、問號、驚嘆號等。</p>
 
-  
+    <p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses, two-em dashes, ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于点号，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於點號，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
 
-
-  <!-- end 3.2 Composition of Ch and W Mixed tests -->
-
-  
-
-
-  <!-- end of 3.3 Ruby  -->
-
-  
-
-  
+    <p its-locale-filter-list="en" lang="en">The content of the following section is mainly based on the content of <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) issued in Mainland China, as well as the <cite>Punctuation Guidance (2008 revised edition)</cite> issued by the Ministry of Education in Taiwan. The former is a recommended national standard while the latter is not mandatory for general publications but mainly used to regulate education materials like textbooks.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">本节主要基于中国大陆的《标点符号用法》（GB/T 15834—2011）及台湾教育部的《重订标点符号手册》（2008年修订版）。前者属推荐标准，后者主要用于规范教科书等教育书籍，对一般出版品不具强制性。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">本節主要基於中國大陸的《標點符號用法》（GB/T 15834—2011）及台灣教育部的《重訂標點符號手冊》（2008年修訂版）。前者屬推薦標準，後者主要用於規範教科書等教育書籍，對一般出版品不具強制性。</p>
 
 </section>
 
@@ -947,9 +1157,9 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的字形、尺寸與字面分布</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">Please find a description of the glyphs and usage of punctuation marks at [[[#categories_and_usage_of_punctuation_marks]]] and [[[#tables_of_chinese_punctuation_marks]]]. There are no notable differences among different regions in the glyphs of punctuation marks. The major differences are their size and where the character face is positioned relative to the character frame.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的字形及用法请见[[[#categories_and_usage_of_punctuation_marks]]]节及[[[#tables_of_chinese_punctuation_marks]]]。各地的标点符号在字形上未有显著差异，区别主要是符号的尺寸与字面分布。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的字形及用法請見[[[#categories_and_usage_of_punctuation_marks]]]節及[[[#tables_of_chinese_punctuation_marks]]]。各地的標點符號在字形上未有顯著差異，區別主要係符號的尺寸與字面分布。</p>
+      <p its-locale-filter-list="en" lang="en">Please find a description of the glyphs and usage of punctuation marks at [[[#h_inline]]] and [[[#tables_of_chinese_punctuation_marks]]]. There are no notable differences among different regions in the glyphs of punctuation marks. The major differences are their size and where the character face is positioned relative to the character frame.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的字形及用法请见[[[#h_inline]]]节及[[[#tables_of_chinese_punctuation_marks]]]。各地的标点符号在字形上未有显著差异，区别主要是符号的尺寸与字面分布。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的字形及用法請見[[[#h_inline]]]節及[[[#tables_of_chinese_punctuation_marks]]]。各地的標點符號在字形上未有顯著差異，區別主要係符號的尺寸與字面分布。</p>
       <p its-locale-filter-list="en" lang="en">Punctuation marks used in Taiwan and Hong Kong are usually positioned in the vertical and horizontal center of the square space left for them; while in vertical writing mode and horizontal writing mode, some of the punctuation marks are positioned in different directions so as to mark the corresponding characters more accurately. In Mainland China, the punctuation marks are usually positioned following the characters they are supposed to mark; while some punctuation marks might be positioned in different directions due to the vertical or horizontal writing mode. Also, different writing modes might require different punctuation marks to fulfill the same function, e.g. horizontal writing mode requires curved quotation marks while vertical writing mode requires corner brackets.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">港台的标点多位于字面正中，部分标号在直、横排中使用不同的方向以准确地标注文字；中国大陆的标点多位于被标注文字的末端、字面始端，部分标号在直、横排中除了使用不同的方向外，亦有需要因文字书写方向替换符号形式的需求，如引号（横排使用弯引号，直排使用直角引号）。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">港台的標點多位於字面正中，部分標號在直、橫排中使用不同的方向以準確地標注文字；中國大陸的標點多位於受注文字的末端、字面始端，部分標號在直、橫排中除了使用不同的方向外，亦有需要因文字書寫方向替換符號形式的需求，如引號（橫排使用彎引號，直排使用直角引號）。</p>
@@ -991,193 +1201,20 @@ var respecConfig = {
 			<p its-locale-filter-list="en" lang="en">Emphasis dots are positioned to the bottom of the marked characters in horizontal writing mode, and to the right of the marked characters in vertical writing mode.</p>
 			<p its-locale-filter-list="zh-hans" lang="zh-hans">着重号横排时标注于文字底部，直排时标注于文字右侧。</p>
 			<p its-locale-filter-list="zh-hant" lang="zh-hant">著重號橫排時標注於文字底部，直排時標注於文字右側。</p>
-	  </section></section>
-
-
-
-
-
-
-
-
-
-
-
-<section id="h_letterforms">
-  <h3>
-    <span its-locale-filter-list="en" lang="en">Letterform slopes, weights, &amp; italics</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h3>
-
-<p>TBD(?)</p>
 </section>
-
-</section>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<section id="h_units">
-  <h2>
-    <span its-locale-filter-list="en" lang="en">Typographic units</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h2>
-
-
-
-<section id="h_encoding">
-  <h3>
-    <span its-locale-filter-list="en" lang="en">Characters &amp; encoding</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h3>
-
-<!--<section id="characters_and_the_principles_of_setting_them_for_chinese_composition">
-    <h3>
-      <span its-locale-filter-list="en" lang="en">Characters and Principles for Arranging Characters in Chinese Composition</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版所使用的文字和基本原则</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版所使用的文字和基本原則</span>
-    </h3>
--->
-    <section id="characters_used_in_chinese_composition">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Characters used for Chinese Composition</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版所使用的文字</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版所使用的文字</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">The majority of the text used in Chinese composition consists of Han characters (Hanzi).</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版主要使用的文字为汉字。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版主要使用的文字為漢字。</p>
-      <p its-locale-filter-list="en" lang="en">Chinese characters include Traditional Chinese and Simplified Chinese alternatives. The former is commonly used in Taiwan, Hong Kong and Macao while the latter is commonly used in Mainland China, Singapore and Malaysia.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">依照各地的通行标准，中文所使用的汉字主要分为繁体字与简体字。前者又称正体字、传统汉字等，主要通行于台湾、香港、澳门等地；后者又作简化字，主要通行于中国大陆、新马地区。本文依笔画多寡与部件结构为区别，分别称为繁体字与简体字。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">依照各地的通行標準，中文所使用的漢字主要分為繁體字與簡體字。前者又作正體字、傳統漢字等，主要通行於台灣、香港、澳門等地；後者又作簡化字，主要通行於中國大陸、星馬地區。本文依筆畫多寡與部件結構為區別，分別稱為繁體字與簡體字。</p>
-      <p its-locale-filter-list="en" lang="en">Different glyphs are used in different regions. One <a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point">Unicode code point</a> of a Han character may have more than one valid glyph, depending on operating system and typeface used. The focus of this document is Chinese composition and will not cover glyph variations in detail.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">不同地区所使用的字形有差异，各种字形与<a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point">Unicode码位</a>并非一一对应关系，需要依赖处理系统和字体来呈现。本文主要探究中文排版，对此不做详述。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">不同地區所使用的字形有差異，各種字形與<a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point">Unicode碼位</a>並非一一對應關係，需要依賴處理系統和字體來呈現。本文主要探究中文排版，對此不做詳述。</p>
-      <p its-locale-filter-list="en" lang="en">In addition to Han characters (Hanzi), various punctuation marks, as well as Western text such as European numerals, Latin letters and/or Greek letters, may be used in Chinese text.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">中文排版除了汉字外，也使用标点符号，也会与阿拉伯数字、拉丁文字、希腊文字等西文混排。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">中文排版除了漢字外，也使用標點符號。也會與阿拉伯數字、拉丁文字、希臘文字等西文混排。</p>
-
-      <div class="note" id="n002">
-        <p its-locale-filter-list="en" lang="en">One Simplified Chinese character may have more than one corresponding Traditional form. For example, the Simplified Chinese character <span lang="zh-hans">发</span> can be mapped to either the Traditional Chinese character <span lang="zh-hant">發</span> or <span lang="zh-hant">髮</span>. By contrast, the circumstances where one Traditional Chinese character corresponds to more than one Simplified Chinese character are fairly rare but still worth noting. For example, the Traditional Chinese character <span lang="zh-hant">乾</span> may be mapped to either the Simplified Chinese character <span lang="zh-hans">干</span> or <span lang="zh-hans">乾</span>. The mapping relationship between Traditional and Simplified Chinese is not one-to-one and particular character conversion depends on its context.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">一个简体字可能对应多个繁体字，如简体字“<span lang="zh-hans">发</span>”，其相应的繁体字可能为“<span lang="zh-hant">發</span>”或“<span lang="zh-hant">髮</span>”；一个繁体汉字对应多个简体汉字的情况与前者相比数量极少但仍需注意，如繁体字“<span lang="zh-hant">乾</span>”可能对应简体字“<span lang="zh-hans">干</span>”或“<span lang="zh-hans">乾</span>”。繁简汉字的对应关系具体应由上下文决定。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">一個簡體字可能對應多個繁體字，如簡體字「<span lang="zh-hans">发</span>」，其相應的繁體字可能為「<span lang="zh-hant">發</span>」或「<span lang="zh-hant">髮</span>」；一個繁體漢字對應多個簡體漢字的情況與前者相比數量極少但仍需注意，如繁體字「<span lang="zh-hant">乾</span>」可能對應簡體字「<span lang="zh-hans">干</span>」或「<span lang="zh-hans">乾</span>」。繁簡漢字的對應關係具體應由上下文決定。</p>
-      </div>
-    </section>
-
-    
-
-
-  <!--</section>-->
-</section>
-
-
-
-
-
-
-
-
-
-
-
-<section id="h_segmentation">
-  <h3>
-    <span its-locale-filter-list="en" lang="en">Grapheme/word segmentation &amp; selection</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h3>
-
-<p>TBD(?)</p>
-</section>
-</section>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<section id="h_inline">
-  <h2>
-    <span its-locale-filter-list="en" lang="en">Punctuation &amp; inline features</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h2>
-
-
 
 <section id="h_phrase">
   <h3>
     <span its-locale-filter-list="en" lang="en">Phrase &amp; section boundaries</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">短语与章节边界</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">短語與章節邊界</span>
   </h3>
 
+    <!-- oldid -->
+    <span id="categories_and_usage_of_punctuation_marks"></span>
 
-
-    <p its-locale-filter-list="en" lang="en">The content of the following section is mainly based on the content of <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) issued in Mainland China, as well as the <cite>Punctuation Guidance (2008 revised edition)</cite> issued by the Ministry of Education in Taiwan. The former is a recommended national standard while the latter is not mandatory for general publications but mainly used to regulate education materials like textbooks.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">本节主要基于中国大陆的《标点符号用法》（GB/T 15834—2011）及台湾教育部的《重订标点符号手册》（2008年修订版）。前者属推荐标准，后者主要用于规范教科书等教育书籍，对一般出版品不具强制性。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">本節主要基於中國大陸的《標點符號用法》（GB/T 15834—2011）及台灣教育部的《重訂標點符號手冊》（2008年修訂版）。前者屬推薦標準，後者主要用於規範教科書等教育書籍，對一般出版品不具強制性。</p>
-
-<!--<section id="categories_and_usage_of_punctuation_marks">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Categories and Usage of Punctuation Marks</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的分类及用法</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的分類及用法</span>
-      </h4>
--->
-      <section id="h-pause-or-stop-punctuation-marks">
-        <h5>
-          <span its-locale-filter-list="en" lang="en">Pause or Stop Punctuation Marks</span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans">点号</span>
-          <span its-locale-filter-list="zh-hant" lang="zh-hant">點號</span>
-        </h5>
-
-        <p its-locale-filter-list="en" lang="en"><a href="#term.pause-or-stop-punctuation-marks" class="termref">Pause or stop punctuation marks</a> are used to indicate pauses or the end of a sentence. Some of the pause or stop punctuation marks appear within a sentence, such as secondary commas, commas, semicolons, colons, etc., while others appear at the end of a sentence, such as periods, question marks and exclamation marks.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>相对于标号，用于表示语句的停顿或暂停。分为句内点号，如顿号、逗号、分号、冒号等；以及句末点号，如句号、问号、感叹号等。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>相對於標號，用於表示語句的停頓或暫停。分為句內點號，如頓號、逗號、分號、冒號等；以及句末點號，如句號、問號、驚嘆號等。</p>
         <ol>
+          <!-- 点号 -->
           <li id="id77">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Periods, commas and secondary commas.</span></p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">句号、逗号与顿号</span></p>
@@ -1209,31 +1246,16 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans">叹号<span class="uname" translate="no">U+FF01 FULLWIDTH EXCLAMATION MARK</span> [！]与问号<span class="uname" translate="no">U+FF1F FULLWIDTH QUESTION MARK</span> [？]。叹号及问号用于句末，前者表示惊讶，后者表示质疑。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">驚嘆號<span class="uname" translate="no">U+FF01 FULLWIDTH EXCLAMATION MARK</span> [！]與問號<span class="uname" translate="no">U+FF1F FULLWIDTH QUESTION MARK</span> [？]。驚嘆號及問號用於句末，前者表示驚訝，後者表示質疑。</p>
           </li>
-        </ol>
-      </section>
 
-      
-
-
-<section id="indication_punctuation_marks">
-        <h5>
-          <span its-locale-filter-list="en" lang="en">Indicator Punctuation Marks</span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans">标号</span>
-          <span its-locale-filter-list="zh-hant" lang="zh-hant">標號</span>
-        </h5>
-
-        <p its-locale-filter-list="en" lang="en">In contrast with <a href="#term.pause-or-stop-punctuation-marks" class="termref">pause or stop punctuation marks</a>, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses, two-em dashes, ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于<a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於<a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
-        <ol>
+          <!-- 标号 -->
           <li id="id83x">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Quotation marks.</span> </p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">引号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">引號</span></p>
 
             <p its-locale-filter-list="en" lang="en">See [[[#h_quotations]]].</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">translate me</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">translate me</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">参见[[[#h_quotations]]]。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">參見[[[#h_quotations]]]。</p>
           </li>
 
           <li id="id81">
@@ -1271,9 +1293,9 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">省略号／删节号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">刪節號／省略號</span></p>
 
-            <p its-locale-filter-list="en" lang="en">See [[[#h_abbrev]]].</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">translate me</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">translate me</p>
+            <p its-locale-filter-list="en" lang="en">See [[[#h_ellipsis]]].</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">参见[[[#h_ellipsis]]]。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">參見[[[#h_ellipsis]]]。</p>
           </li>
           <li id="id85">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Connector Marks.</span></p>
@@ -1330,13 +1352,13 @@ var respecConfig = {
             </div>
           </li>
         </ol>
-      </section>
-    
-    
-    
-    
-    
-    
+      <!-- </section> -->
+
+
+
+
+
+
 
 
     <section id="atypical_punctuation_marks_and_their_arrangements">
@@ -1433,15 +1455,10 @@ var respecConfig = {
 <section id="h_quotations">
   <h2>
     <span its-locale-filter-list="en" lang="en">Quotations &amp; citations</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">行内文字排版处理</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">行內文字排版處理</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">引文</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">引文</span>
   </h2>
 
-
-
-        <p its-locale-filter-list="en" lang="en">In contrast with <a href="#term.pause-or-stop-punctuation-marks" class="termref">pause or stop punctuation marks</a>, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses, two-em dashes, ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于<a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於<a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
         <ol>
           <li id="id80">
             <p its-locale-filter-list="en" lang="en"><span class="leadin">Quotation Marks</span></p>
@@ -1528,23 +1545,25 @@ var respecConfig = {
 <section id="h_emphasis">
   <h2>
     <span its-locale-filter-list="en" lang="en">Emphasis &amp; highlighting</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">强调与突出显示</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">強調與突出顯示</span>
   </h2>
 
-<!--<ul>
-          <li id="id84">-->
-            <!--<p its-locale-filter-list="en" lang="en"><span class="leadin">Emphasis Dots.</span></p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">着重号</span></p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">着重號</span></p>-->
+  <section id="id84">
+    <h2>
+      <span its-locale-filter-list="en" lang="en">Emphasis Dots</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">着重号</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">着重號</span>
+    </h2>
+
             <p its-locale-filter-list="en" lang="en">Emphasis dots are symbols placed on the <a href="#term.line-head" class="termref">line head</a> or <a href="#term.line-foot" class="termref">line foot</a> to emphasize the text, strengthen the tone, or avoid ambiguity. For horizontal writing mode, emphasis dots are placed under the characters, whereas in vertical writing mode, they are usually placed to the right side of the characters. Both <span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●] or <span class="uname" translate="no">U+2022 BULLET</span> [•] can work as emphasis dots.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">着重号用于表示相应文本的强调、着重语气或避免歧义。其形态为标注于文字底端或顶端（横排多在下方〔底端〕、直排多在右侧〔顶端〕）的圆形中黑点，可以为<span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●]或<span class="uname" translate="no">U+2022 BULLET</span> [•]。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">着重號用於表示相應文本的強調、着重語氣或避免歧義。其形態為標注於文字底端或頂端（橫排多在下方〔底端〕、直排多在右側〔頂端〕）的圓形中黑點，可以為<span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●]或<span class="uname" translate="no">U+2022 BULLET</span> [•]。</p>
             <p its-locale-filter-list="en" lang="en"><cite>Punctuation Guidance</cite> (revised edition) issued by The Ministry of Education in Taiwan does not include this mark but it can still be seen in some publications.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">台湾教育部的《重订标点符号手册》（2008年修订版）中未收录此符号，但仍可见于部分台湾的出版物。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">台灣教育部的《重訂標點符號手冊》（2008年修訂版）中未收錄此符號，但仍可見於部分台灣的出版物</p>
-          <!--</li>
-</ul>-->
+
+</section>
 </section>
 
 
@@ -1560,8 +1579,8 @@ var respecConfig = {
 <section id="h_abbrev">
   <h3>
     <span its-locale-filter-list="en" lang="en">Abbreviation, ellipsis &amp; repetition</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">缩写、省略与重复</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">縮寫、省略與重複</span>
   </h3>
 
 <section id="h_ellipsis">
@@ -1612,8 +1631,8 @@ var respecConfig = {
 <section id="h_inline_notes">
   <h2>
     <span its-locale-filter-list="en" lang="en">Inline notes &amp; annotations</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">行内注、行间注与批注</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">行內注、行間注與批注</span>
   </h2>
 
 
@@ -2146,8 +2165,8 @@ var respecConfig = {
 <section id="h_text_decoration">
   <h2>
     <span its-locale-filter-list="en" lang="en">Text decoration &amp; other inline features</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">文本装饰与其他行内特性</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">文本裝飾與其他行內特性</span>
   </h2>
 
 <section id="handling_interlinear_punctuation">
@@ -2242,8 +2261,8 @@ var respecConfig = {
 <section id="h_data">
   <h3>
     <span its-locale-filter-list="en" lang="en">Data formats &amp; numbers</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">数据格式与数字</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">數據格式與數字</span>
   </h3>
 
 <p>TBD(?)</p>
@@ -2274,21 +2293,21 @@ var respecConfig = {
 <section id="h_para">
   <h2>
     <span its-locale-filter-list="en" lang="en">Line &amp; paragraph layout</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版基础</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版基礎</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">行与段落版式</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">行與段落版式</span>
   </h2>
 
-  
 
 
-  
+
+
 
 
 <section id="h_line_breaking">
   <h2>
     <span its-locale-filter-list="en" lang="en">Line breaking &amp; hyphenation</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">换行与断词连字</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">換行與斷詞連字</span>
   </h2>
 
 <section id="prohibition_rules_for_line_start_end">
@@ -2502,96 +2521,10 @@ var respecConfig = {
 <section id="h_justification">
   <h2>
     <span its-locale-filter-list="en" lang="en">Text alignment &amp; justification</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">文本对齐</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">文本對齊</span>
   </h2>
 
-<section id="chinese_and_western_mixed_text_composition2">
-<h3>
-      <span its-locale-filter-list="en" lang="en">Composition of Chinese and Western Mixed Texts</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">中、西文混排处理</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">中、西文混排處理</span>
-    </h3>
-<section id="handling_western_text_in_chinese_text_using_proportional_western_fonts">
-  <h4>
-        <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
-</h4>
-
-      <p its-locale-filter-list="en" lang="en">The following provides composition rules for handling Western alphas and European numerals in horizontal writing mode or for situations in vertical writing mode where the words/phrases of Western alphas or European numerals are rotated 90 degrees clockwise:</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">横排中混排的西文字母、阿拉伯数字，及直排中将文字采顺时针旋转90°配置的西文字母、阿拉伯数字，其配置方式如下：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排中混排的西文字母、阿拉伯數字，及直排中將文字採順時針旋轉90度配置的西文字母、阿拉伯數字，其配置方式如下：</p>
-      <ol>
-        <li id="id114">
-          <p its-locale-filter-list="en" lang="en">A sequence of Western characters in a Western word should not break across a line-break, except where hyphenation is allowed.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">西文单字词在可使用连字符处之外，不得分隔为两行。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">西文單字詞在可使用連字符處之外，不得分隔為兩行。</p>
-        </li>
-        <li id="id115">
-          <p its-locale-filter-list="en" lang="en" class="checkme">Tracking or spacing between a Han character and an alphanumeric is up to 1/4&nbsp;em.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字之间，原则上使用不多于四分之一个汉字宽的字距或空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字之間，原則上使用不多於四分之一個漢字寬的字距或空白。</p>
-        </li>
-        <li id="id116">
-          <p its-locale-filter-list="en" lang="en">Justified text alignment is an important feature of Chinese composition. It is harder to align text as expected when a line contains Western characters. Typically, spacing or tracking is applied equally across the line, but such adjustments are only applied between Han characters, or between a Han character and a Western character. The spacing is not equally distributed between characters in Western words and/or European numerals.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">由于中文排版强调行首与行尾对齐，当行内包含西文时，较难对齐，这时多使用均排的方式处理。均排时，各西文词组间、阿拉伯数字间的空格，以及西文字母与阿拉伯数字之间不使用均排，仅调整汉字、汉字与西文间的字距或空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">由於中文排版強調行頭與行尾對齊，當行內包含西文時，較難對齊，這時多使用均排的方式處理。均排時，各西文詞組間、阿拉伯數字間之空格，以及西文字母與阿拉伯數字之間不使用均排，僅調整漢字、漢字與西文間的字距或空白。</p>
-        </li>
-      </ol>
-      <p its-locale-filter-list="en" lang="en">Exceptions are made in the following cases:</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">以下情况例外：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">以下情況例外：</p>
-      <ol>
-        <li id="id117">
-          <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or <a href="#term.european-numerals" class="termref">European numerals</a> before the line start or after the line end are not justified.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">位于行首的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之前、位于行尾的西文字母与<a href="#term.european-numerals" class="termref">阿拉伯数字</a>之后不调整字距或加入空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行頭的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之前、位於行尾的西文字母與<a href="#term.european-numerals" class="termref">阿拉伯數字</a>之後不調整字距或加入空白。</p>
-        </li>
-        <li id="id118">
-          <p its-locale-filter-list="en" lang="en">Tracking or spacing of Western alphas or European numerals is not adjusted before or after Chinese commas or full stops, nor after Chinese opening and before Chinese closing brackets.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">在中文点号前后、中文开始夹注符号之后、结束夹注符号之前的西文字母或阿拉伯数字，不调整字距或加入空白。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">於中文點號前後、中文開始夾注符號之後、結束夾注符號之前的西文字母或阿拉伯數字，不調整字距或加入空白。</p>
-        </li>
-      </ol>
-</section>
-
-
-    <section id="handling_of_grid_alignment_in_chinese_and_western_mixed_text_composition">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Handling of Grid Alignment in Chinese and Western Mixed Text Composition</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐下的中西文混排处理</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊下的中西文混排處理</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">Due to the fact that each Han character is of the same width, not only should characters at the start and end of a line be aligned but it is also a requirement for characters within blocks of Han text to be aligned both vertically and horizontally, whether in vertical or horizontal writing mode. When Western alphas or European numerals are present, this principle is harder to achieve. Possible approaches are listed below:</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">由于汉字各字等宽的性质，无论在直排或横排的情况下，除了行齐首尾对齐外，亦求各行间的各个汉字能够纵横对齐。若遇西文字母或阿拉伯数字采用比例字体，难以满足这项原则时，处理方式如下：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">由於漢字各字等寬的性質，無論在直排或橫排的情況下，除了行齊頭尾對齊外，亦求各行間的各個漢字能夠縱橫對齊。若遇西文字母或阿拉伯數字採用比例字體，便難以滿足這項原則，處理方式如下：</p>
-      <ol>
-        <li id="id119">
-          <p its-locale-filter-list="en" lang="en" class="checkme">Instead of 1/4-em spacing between a Han character and an alphanumeric, it is possible to use flexible spacing of up to 1/2&nbsp;em. This brings the space occupied by Western characters to a multiple of the width of a Han character. In this way, both the Han characters before and after a Western text span snap to the grid lines.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">汉字与西文字母或阿拉伯数字间不使用四分之一汉字宽的字距，而是加入大于零、小于等于二分之一汉字宽的弹性空白，使西文所占的空间为汉字的整数倍，确保西文前后的汉字都能纵横对齐。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">漢字與西文字母或阿拉伯数字間不使用四分之一漢字寬之字距，而是加入大於零、小於等於二分之一漢字寬的彈性空白，使西文所佔之空間為漢字的整數倍，確保西文前後之漢字都能縱橫對齊。</p>
-        </li>
-        <li id="id120">
-          <p its-locale-filter-list="en" lang="en">When a Western word appears at the line end and needs to be broken, rather than breaking the word at a syllable boundary per the Western convention, the word may be forced to break at the line end, in order to ensure correct alignment.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">当西文单词位于行尾必须断行时，无须遵照西文从音节断行的惯例，在行尾强制断行，以确保行尾对齐。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">當西文單詞位於行尾必須斷行時，無須遵照西文從音節斷行的慣例，於行尾強制斷行，以確保行尾對齊。</p>
-        </li>
-      </ol>
-      <div class="note" id="n039">
-        <p its-locale-filter-list="en" lang="en">When using grid alignment, it is recommended to deal with line end punctuation marks by hanging the first of them outside the type area as mentioned in section [[[#hanging_punctuation_marks_at_line_end]]]. In situations that involve consecutive punctuation marks, the second and following punctuation marks are allowed to appear at the line start.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐时，可配合[[[#hanging_punctuation_marks_at_line_end]]]节的行尾点号悬挂方式处理标点禁则，若遇两个以上连续标点时，第二个及其后之标点可令其出现于行首。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊時，可配合[[[#hanging_punctuation_marks_at_line_end]]]節的行尾點號懸掛方式處理標點禁則，若遇兩個以上連續標點時，第二個及其後之標點可令其出現於行首。</p>
-      </div>
-      <div class="note" id="n040">
-        <p its-locale-filter-list="en" lang="en">Grid alignment is adopted more often in Traditional Chinese typesetting, whereas use in Simplified Chinese is rare.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐多使用于繁体中文排版，简体中文较为少见。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊多使用於繁體中文排版，簡體中文較為少見。</p>
-      </div>
-    </section>
-
-</section>
 
 
 
@@ -2734,411 +2667,403 @@ var respecConfig = {
         </li>
       </ol>
     </section>
-
-
-    
-  
-
-
-
-
-
-
-
-
+</section>
 
 <section id="line_adjustment">
-    <h3>
-      <span its-locale-filter-list="en" lang="en">Line Adjustment</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">行内调整</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">行內調整</span>
-    </h3>
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Line Adjustment</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">行内调整</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">行內調整</span>
+  </h3>
 
-    <section id="necessity_for_line_adjustment">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Necessity for Line Adjustment</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">行内调整的必要性</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">行內調整的必要性</span>
-      </h4>
+  <section id="necessity_for_line_adjustment">
+    <h4>
+      <span its-locale-filter-list="en" lang="en">Necessity for Line Adjustment</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">行内调整的必要性</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">行內調整的必要性</span>
+    </h4>
 
-      <p its-locale-filter-list="en" lang="en">
-        There are numerous reasons, e.g. [[[#prohibition_rules_for_line_start_end]]], that result in line lengths being uneven. Under such circumstances, <a href="#term.line-adjustment" class="termref">line adjustment</a> is required. With the exception of [[[#prohibition_rules_for_unbreakable_marks]]], a run of text may be broken at the specified line length, allowing the text to be arranged into even rows. Other than the last line of a paragraph, the start and end of a line must be placed at the specified line start and line end position respectively. The last line of the paragraph will be adjusted accordingly to the overall flow of the text with adjustments made to the width of its punctuation. It is not necessary for the end of the last line to be aligned with the rest of the text. Please refer to [[[#adjustments_of_orphans_and_widows]]]. If the text only comprises of 1 line, please refer to [[[#ways_of_alignments]]].
-      </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        由于[[[#prohibition_rules_for_line_start_end]]]等原因造成行的长度长短不一，这时需要进行“<a href="#term.line-adjustment" class="termref">行内调整</a>”。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先将整段文字按照指定的行长断开，排列成行。对于除了段落最后一行以外的各行，其行首、行尾必须分别放到指定行长的位置。对于段落最后一行，原则上按照排版风格进行标点宽度调整即可，末尾没有必要与指定行长的行尾对齐；最后一行需要调整的特殊情况，请参照[[[#adjustments_of_orphans_and_widows]]]。而当段落有且仅有一行时，请参照[[[#ways_of_alignments]]]。
-      </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        由於[[[#prohibition_rules_for_line_start_end]]]等原因造成行的長度長短不一，這時需要進行「<a href="#term.line-adjustment" class="termref">行內調整</a>」。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先將整段文字按照指定的行長斷開，排列成行。對於除了段落最後一行以外的各行，其行首、行尾必須分別放到指定行長的位置。對於段落最後一行，原則上按照排版風格進行標點寬度調整即可，末尾沒有必要與指定行長的行尾對齊；最後一行需要調整的特殊情況，請參照[[[#adjustments_of_orphans_and_widows]]]。而當段落有且僅有一行時，請參照[[[#ways_of_alignments]]]。
-      </p>
+    <p its-locale-filter-list="en" lang="en">
+      There are numerous reasons, e.g. [[[#prohibition_rules_for_line_start_end]]], that result in line lengths being uneven. Under such circumstances, <a href="#term.line-adjustment" class="termref">line adjustment</a> is required. With the exception of [[[#prohibition_rules_for_unbreakable_marks]]], a run of text may be broken at the specified line length, allowing the text to be arranged into even rows. Other than the last line of a paragraph, the start and end of a line must be placed at the specified line start and line end position respectively. The last line of the paragraph will be adjusted accordingly to the overall flow of the text with adjustments made to the width of its punctuation. It is not necessary for the end of the last line to be aligned with the rest of the text. Please refer to [[[#adjustments_of_orphans_and_widows]]]. If the text only comprises of 1 line, please refer to [[[#ways_of_alignments]]].
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      由于[[[#prohibition_rules_for_line_start_end]]]等原因造成行的长度长短不一，这时需要进行“<a href="#term.line-adjustment" class="termref">行内调整</a>”。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先将整段文字按照指定的行长断开，排列成行。对于除了段落最后一行以外的各行，其行首、行尾必须分别放到指定行长的位置。对于段落最后一行，原则上按照排版风格进行标点宽度调整即可，末尾没有必要与指定行长的行尾对齐；最后一行需要调整的特殊情况，请参照[[[#adjustments_of_orphans_and_widows]]]。而当段落有且仅有一行时，请参照[[[#ways_of_alignments]]]。
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      由於[[[#prohibition_rules_for_line_start_end]]]等原因造成行的長度長短不一，這時需要進行「<a href="#term.line-adjustment" class="termref">行內調整</a>」。在除了[[[#prohibition_rules_for_unbreakable_marks]]]以外的的地方，先將整段文字按照指定的行長斷開，排列成行。對於除了段落最後一行以外的各行，其行首、行尾必須分別放到指定行長的位置。對於段落最後一行，原則上按照排版風格進行標點寬度調整即可，末尾沒有必要與指定行長的行尾對齊；最後一行需要調整的特殊情況，請參照[[[#adjustments_of_orphans_and_widows]]]。而當段落有且僅有一行時，請參照[[[#ways_of_alignments]]]。
+    </p>
 
-      <p its-locale-filter-list="en" lang="en">
-        There are a number of reasons for line adjustment, mainly:
-      </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        造成需要行内调整的原因有很多，主要有：
-      </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        造成需要行內調整的原因有很多，主要有：
-      </p>
+    <p its-locale-filter-list="en" lang="en">
+      There are a number of reasons for line adjustment, mainly:
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      造成需要行内调整的原因有很多，主要有：
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      造成需要行內調整的原因有很多，主要有：
+    </p>
 
-      <ol type="a">
-        <li>
-          <p its-locale-filter-list="en" lang="en">
-            Lines which are interspersed with many <a href="#term.european-numerals" class="termref">European numerals</a>, Western alphas or other non-full width characters;
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            行内夹杂了<a href="#term.european-numerals" class="termref">阿拉伯数字</a>、西文字母等非一个汉字字宽的字符；
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            行內夾雜了<a href="#term.european-numerals" class="termref">阿拉伯數字</a>、西文字母等非一個漢字字寬的字符；
-          </p>
-        </li>
-        <li>
-          <p its-locale-filter-list="en" lang="en">
-            Instances where punctuation marks occur consecutively and still remain uneven after [[[#h-adjustment_of_adjacent_punctuation_marks]]];
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            标点符号连续出现，且按照[[[#h-adjustment_of_adjacent_punctuation_marks]]]的原则性调整之后与事先设定的行长不一致；
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            標點符號連續出現，且按照[[[#h-adjustment_of_adjacent_punctuation_marks]]]的原則性調整之後與事先設定的行長不一致；
-          </p>
-        </li>
-        <li>
-          <p its-locale-filter-list="en" lang="en">
-            Lines containing characters of different font sizes;
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            行内混用不同字号，比如该行有“行内夹注”并使用了小一些的字号；
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            行內混用不同字號，比如該行有「行內夾註」並使用了小一些的字號；
-          </p>
-        </li>
-        <li>
-          <p its-locale-filter-list="en" lang="en">
-            After the processing of punctuation in accordance with [[[#prohibition_rules_for_line_start_end]]].
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            标点符号依照[[[#prohibition_rules_for_line_start_end]]]进行了处理。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            標點符號依照[[[#prohibition_rules_for_line_start_end]]]進行了處理。
-          </p>
-        </li>
-      </ol>
-
-      <p its-locale-filter-list="en" lang="en">
-        In contrast to Western typesetting, the body text in Chinese books are rarely left-aligned, and instead should be justified. Justification of Western text hinges on the adjustment of space between the words on a line, whereas there are more options for line justification when it comes to Chinese typesetting.
-      </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        与西文排版不同，中文排版特别是书籍正文排版极少使用左齐右不齐，原则上应该进行两端对齐。西文排版两端对齐（justification）时，主要是调整单词之间的间隙（词距），而中文排版在两端对齐时，能调整的地方更多，具体如下所述。
-      </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        與西文排版不同，中文排版特別是書籍正文排版極少使用左齊右不齊，原則上應該進行兩端對齊。西文排版兩端對齊（justification）時，主要是調整單詞之間的間隙（詞距），而中文排版在兩端對齊時，能調整的地方更多，具體如下所述。
-      </p>
-
-    </section>
-
-    <section id="reduction_and_expansion_of_inter-character_spacing">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Reduction and Expansion of Inter-Character Spacing</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">挤压处理和拉伸处理</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">擠壓處理和拉伸處理</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">
-        Line adjustments are predicated upon the amount of available space, for example, spacing between Western words, [[[#h-punctuation_adjustment_space]]], and so on. There are two methods for line adjustment:
-      </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        行内调整的对象是需要按照预先定义的可调整空间，如西文词距、[[[#h-punctuation_adjustment_space]]]等等。行内调整有以下两种方法：
-      </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        行內調整的對象是需要按照預先定義的可調整空間，如西文詞距、[[[#h-punctuation_adjustment_space]]]等等。行內調整有以下兩種方法：
-      </p>
-
-      <ol type="a">
-        <li>
-          <p its-locale-filter-list="en" lang="en">
-            <span class="leadin">Reduction of Inter-Character Spacing:</span>
-            Inter-character spacing like those between Western words, mixed texts, or as described in [[[#h-punctuation_adjustment_space]]], should be reduced in accordance to the prevailing typesetting style.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            <span class="leadin">挤压处理：</span>“挤压处理”是指按照预先规定的排版风格，压缩西文词距、中西间距和[[[#h-punctuation_adjustment_space]]]等处的做法。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            <span class="leadin">擠壓處理：</span>「擠壓處理」是指按照預先規定的排版風格，壓縮西文詞距、中西間距和[[[#h-punctuation_adjustment_space]]]等處的做法。
-          </p>
-        </li>
-
-        <li>
-          <p its-locale-filter-list="en" lang="en">
-            <span class="leadin">Expansion of Inter-Character Spacing:</span>
-            Inter-character spacing like those between Western words, mixed texts or scenarios that are not limited by prohibition rules should be added in accordance to the prevailing typesetting style.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            <span class="leadin">拉伸处理：</span>“拉伸处理”是指按照预先规定的排版风格，拉伸西文词距、中西间距以及其他未被特殊规定禁止调整等处的做法。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">
-            <span class="leadin">拉伸處理：</span>「拉伸處理」是指按照預先規定的排版風格，拉伸西文詞距、中西間距以及其他未被特殊規定禁止調整等處的做法。
-          </p>
-        </li>
-      </ol>
-
-      <p its-locale-filter-list="en" lang="en">
-        In order to make the composition tighter and more readable, the guiding principle is to attempt to implement space reduction first. In the event that is insufficient, then space can be added where acceptable to achieve justification.
-      </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        出于紧凑易读、节约版面的思路，行内调整要遵循“先挤压、后拉伸”的原则，即应该先挤压处理，仍旧无法满足需求之后再进行拉伸处理。
-      </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        出於緊湊易讀、節約版面的思路，行內調整要遵循「先擠壓、後拉伸」的原則，即應該先擠壓處理，仍舊無法滿足需求之後再進行拉伸處理。
-      </p>
-
-      <div class="note">
+    <ol type="a">
+      <li>
         <p its-locale-filter-list="en" lang="en">
-          The word spacing in Western text described here only pertains to situations which involve compositions of mixed Western and Han characters. The expected behaviour is different from that for purely Western texts, which will take into account the typeface, font size and letter spacing when doing text justification. In general, Western texts will add to word spacing and rarely uses space reduction.
+          Lines which are interspersed with many <a href="#term.european-numerals" class="termref">European numerals</a>, Western alphas or other non-full width characters;
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
-          本文涉及到行内的“西文词距”调整，仅是针对“在中文排版内混排的西文”，因此，与纯西文排版的习惯不尽相同。一般的西文排版中的词距，需要依照所用字体、字号、字距进行不同判断，而且一般只拉伸、不挤压。
+          行内夹杂了<a href="#term.european-numerals" class="termref">阿拉伯数字</a>、西文字母等非一个汉字字宽的字符；
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          行內夾雜了<a href="#term.european-numerals" class="termref">阿拉伯數字</a>、西文字母等非一個漢字字寬的字符；
+        </p>
+      </li>
+      <li>
+        <p its-locale-filter-list="en" lang="en">
+          Instances where punctuation marks occur consecutively and still remain uneven after [[[#h-adjustment_of_adjacent_punctuation_marks]]];
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          标点符号连续出现，且按照[[[#h-adjustment_of_adjacent_punctuation_marks]]]的原则性调整之后与事先设定的行长不一致；
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          標點符號連續出現，且按照[[[#h-adjustment_of_adjacent_punctuation_marks]]]的原則性調整之後與事先設定的行長不一致；
+        </p>
+      </li>
+      <li>
+        <p its-locale-filter-list="en" lang="en">
+          Lines containing characters of different font sizes;
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          行内混用不同字号，比如该行有“行内夹注”并使用了小一些的字号；
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          行內混用不同字號，比如該行有「行內夾註」並使用了小一些的字號；
+        </p>
+      </li>
+      <li>
+        <p its-locale-filter-list="en" lang="en">
+          After the processing of punctuation in accordance with [[[#prohibition_rules_for_line_start_end]]].
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          标点符号依照[[[#prohibition_rules_for_line_start_end]]]进行了处理。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          標點符號依照[[[#prohibition_rules_for_line_start_end]]]進行了處理。
+        </p>
+      </li>
+    </ol>
+
+    <p its-locale-filter-list="en" lang="en">
+      In contrast to Western typesetting, the body text in Chinese books are rarely left-aligned, and instead should be justified. Justification of Western text hinges on the adjustment of space between the words on a line, whereas there are more options for line justification when it comes to Chinese typesetting.
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      与西文排版不同，中文排版特别是书籍正文排版极少使用左齐右不齐，原则上应该进行两端对齐。西文排版两端对齐（justification）时，主要是调整单词之间的间隙（词距），而中文排版在两端对齐时，能调整的地方更多，具体如下所述。
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      與西文排版不同，中文排版特別是書籍正文排版極少使用左齊右不齊，原則上應該進行兩端對齊。西文排版兩端對齊（justification）時，主要是調整單詞之間的間隙（詞距），而中文排版在兩端對齊時，能調整的地方更多，具體如下所述。
+    </p>
+
+  </section>
+
+  <section id="reduction_and_expansion_of_inter-character_spacing">
+    <h4>
+      <span its-locale-filter-list="en" lang="en">Reduction and Expansion of Inter-Character Spacing</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">挤压处理和拉伸处理</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">擠壓處理和拉伸處理</span>
+    </h4>
+
+    <p its-locale-filter-list="en" lang="en">
+      Line adjustments are predicated upon the amount of available space, for example, spacing between Western words, [[[#h-punctuation_adjustment_space]]], and so on. There are two methods for line adjustment:
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      行内调整的对象是需要按照预先定义的可调整空间，如西文词距、[[[#h-punctuation_adjustment_space]]]等等。行内调整有以下两种方法：
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      行內調整的對象是需要按照預先定義的可調整空間，如西文詞距、[[[#h-punctuation_adjustment_space]]]等等。行內調整有以下兩種方法：
+    </p>
+
+    <ol type="a">
+      <li>
+        <p its-locale-filter-list="en" lang="en">
+          <span class="leadin">Reduction of Inter-Character Spacing:</span>
+          Inter-character spacing like those between Western words, mixed texts, or as described in [[[#h-punctuation_adjustment_space]]], should be reduced in accordance to the prevailing typesetting style.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          <span class="leadin">挤压处理：</span>“挤压处理”是指按照预先规定的排版风格，压缩西文词距、中西间距和[[[#h-punctuation_adjustment_space]]]等处的做法。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          <span class="leadin">擠壓處理：</span>「擠壓處理」是指按照預先規定的排版風格，壓縮西文詞距、中西間距和[[[#h-punctuation_adjustment_space]]]等處的做法。
+        </p>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en">
+          <span class="leadin">Expansion of Inter-Character Spacing:</span>
+          Inter-character spacing like those between Western words, mixed texts or scenarios that are not limited by prohibition rules should be added in accordance to the prevailing typesetting style.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          <span class="leadin">拉伸处理：</span>“拉伸处理”是指按照预先规定的排版风格，拉伸西文词距、中西间距以及其他未被特殊规定禁止调整等处的做法。
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">
-          本文涉及到行內的「西文詞距」調整，僅是針對「在中文排版內混排的西文」，因此，與純西文排版的習慣不盡相同。一般的西文排版中的詞距，需要依照所用字體、字號、字距進行不同判斷，而且一般只拉伸、不擠壓。
+          <span class="leadin">拉伸處理：</span>「拉伸處理」是指按照預先規定的排版風格，拉伸西文詞距、中西間距以及其他未被特殊規定禁止調整等處的做法。
         </p>
-      </div>
+      </li>
+    </ol>
 
-    </section>
+    <p its-locale-filter-list="en" lang="en">
+      In order to make the composition tighter and more readable, the guiding principle is to attempt to implement space reduction first. In the event that is insufficient, then space can be added where acceptable to achieve justification.
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      出于紧凑易读、节约版面的思路，行内调整要遵循“先挤压、后拉伸”的原则，即应该先挤压处理，仍旧无法满足需求之后再进行拉伸处理。
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      出於緊湊易讀、節約版面的思路，行內調整要遵循「先擠壓、後拉伸」的原則，即應該先擠壓處理，仍舊無法滿足需求之後再進行拉伸處理。
+    </p>
 
-    <section id="procedures_for_inter-character_spacing_reduction">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Procedures for Inter-Character Spacing Reduction</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">挤压处理的优先顺序</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">擠壓處理的優先順序</span>
-      </h4>
-
+    <div class="note">
       <p its-locale-filter-list="en" lang="en">
-        Inter-character spacing reduction should be processed according to the following steps, in order of precedence:
+        The word spacing in Western text described here only pertains to situations which involve compositions of mixed Western and Han characters. The expected behaviour is different from that for purely Western texts, which will take into account the typeface, font size and letter spacing when doing text justification. In general, Western texts will add to word spacing and rarely uses space reduction.
       </p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        行内调整的挤压处理，应该按照下述步骤，确定挤压的优先顺序后依次进行处理：
+        本文涉及到行内的“西文词距”调整，仅是针对“在中文排版内混排的西文”，因此，与纯西文排版的习惯不尽相同。一般的西文排版中的词距，需要依照所用字体、字号、字距进行不同判断，而且一般只拉伸、不挤压。
       </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        行內調整的擠壓處理，應該按照下述步驟，確定擠壓的優先順序後依次進行處理：
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">
+        本文涉及到行內的「西文詞距」調整，僅是針對「在中文排版內混排的西文」，因此，與純西文排版的習慣不盡相同。一般的西文排版中的詞距，需要依照所用字體、字號、字距進行不同判斷，而且一般只拉伸、不擠壓。
       </p>
+    </div>
 
-      <ol type="a">
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            At the end of a line: adjusted to fixed 1/2&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            位于行末的标点。调成固定的半个汉字宽。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            位於行末的標點。調成固定的半個漢字寬。
-          </p>
-          <aside class="note">
-            <p its-locale-filter-list="en" lang="en">
-              In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up 1/2&nbsp;em for a more pleasing aesthetic.
-            </p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">
-              行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定“5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。”
-            </p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-              行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全形字符則應占半形字符的寬度（即半個字位置），以使視覺效果更美觀。」
-            </p>
-          </aside>
-        </li>
+  </section>
 
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Spacing between Western text: for lines with numerous instances of Western text, their spacing should be processed at the same time, with equal treatment. The minimum space between each Western text should be 1/4&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            位于行内的西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最小可以挤压到四分之一汉字宽。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            位於行內的西文詞距。一行內若有多處西文詞距，應該同時、同等量處理，每個西文詞距最小可以擠壓到四分之一漢字寬。
-          </p>
-        </li>
+  <section id="procedures_for_inter-character_spacing_reduction">
+    <h4>
+      <span its-locale-filter-list="en" lang="en">Procedures for Inter-Character Spacing Reduction</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">挤压处理的优先顺序</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">擠壓處理的優先順序</span>
+    </h4>
 
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Interpuncts: space reduction must take place equally on both sides of the character. The minimum space is 0, whereby the interpunct ends up being 1/2&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            位于行内的间隔号。挤压时必须同时从字面两侧、同等量处理，最小挤到0，即变成半个汉字字宽。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            位於行內的間隔號。擠壓時必須同時從字面兩側、同等量處理，最小擠到0，即變成半個漢字字寬。
-          </p>
-        </li>
+    <p its-locale-filter-list="en" lang="en">
+      Inter-character spacing reduction should be processed according to the following steps, in order of precedence:
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      行内调整的挤压处理，应该按照下述步骤，确定挤压的优先顺序后依次进行处理：
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      行內調整的擠壓處理，應該按照下述步驟，確定擠壓的優先順序後依次進行處理：
+    </p>
 
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Brackets: space reduction can take place before the opening bracket and after the closing bracket. If multiple brackets occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the bracket is 1/2&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            位于行内的夹注符号。可以对开始夹注符号的前侧、结束夹注符号的后侧进行挤压，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            位於行內的夾註符號。可以對開始夾註符號的前側、結束夾註符號的後側進行擠壓，最小可以擠壓到半個漢字字寬。壹行內如有多處，應該同時、同等量處理。
-          </p>
-        </li>
-
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Commas, secondary commas and semi-colons: space reduction should follow [[[#h-punctuation_adjustment_space]]]. Spacing can be reduced at the end of the punctuation mark or equally on either side. If multiple of such punctuations occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the punctuation mark is 1/2&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            位于行内的逗号、顿号、分号。挤压空间依照[[[#h-punctuation_adjustment_space]]]，可以是后侧，也可以是字面两侧同时，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            位於行內的逗號、頓號、分號。擠壓空間依照[[[#h-punctuation_adjustment_space]]]，可以是後側，也可以是字面兩側同時，最小可以擠壓到半個漢字字寬。一行內如有多處，應該同時、同等量處理。
-          </p>
-        </li>
-
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Spacing between Han characters and Western texts: if there are numerous instances of mixed texts, space reduction should be processed at the same time, with equal treatment, with the minimum space being 1/8&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            行内的中西间距，最小挤为八分之一汉字宽。一行内若有多处，应该同时、同等量处理。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            行內的中西間距，最小擠為八分之一漢字寬。一行內若有多處，應該同時、同等量處理。
-          </p>
-          <aside class="note">
-            <p its-locale-filter-list="en" lang="en" class="checkme">
-              Certain typesetting styles have a fixed default spacing between Han characters and Western texts, for example 1/4&nbsp;em, in such cases, adjustment is not allowed.
-            </p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">
-              在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被挤压。
-            </p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-              在一些排版風格中，中西間距固定默認寬度（如四分之一漢字寬），被排除在行內調整對象之外，不允許被擠壓。
-            </p>
-          </aside>
-        </li>
-
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Periods, question marks and exclamation marks: in accordance to [[[#h-punctuation_adjustment_space]]], if there is available space, spacing can be reduced up until the minimum size of 1/2&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            位于行内的句号、问号、感叹号。依照[[[#h-punctuation_adjustment_space]]]，如果有调整空间则可以挤压，最小挤为半个汉字字宽。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            位於行內的句號、問號、驚嘆號。依照[[[#h-punctuation_adjustment_space]]]，如果有調整空間則可以擠壓，最小擠為半個漢字字寬。
-          </p>
-          <aside class="note">
-            <p its-locale-filter-list="en" lang="en" class="checkme">
-              As these punctuation marks indicate a longer pause at the end of a sentence, certain typesetting styles do not allow line adjustment to be made on them, maintaining their width to be 1&nbsp;em.
-            </p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">
-              由于句末标点表示停顿较大，因此有些排版风格禁止此项调整，而保持句号、问号、感叹号固定一个字宽。
-            </p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-              由於句末標點表示停頓較大，因此有些排版風格禁止此項調整，而保持句號、問號、驚嘆號固定一個字寬。
-            </p>
-          </aside>
-        </li>
-      </ol>
-    </section>
-
-    <section id="procedures_for_inter-character_space_expansion">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Procedures for Inter-Character Space Expansion</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">拉伸处理的优先顺序</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">拉伸處理的優先順序</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">
-        Inter-character space expansion should be processed according to the following steps, in order of precedence:
-      </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">
-        行内调整的拉伸处理，应该按照下述步骤，确定拉伸的优先顺序后依次进行处理：
-      </p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-        行內調整的拉伸處理，應該按照下述步驟，確定拉伸的優先順序後依次進行處理：
-      </p>
-
-      <ol type="a">
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Word spacing between Western text: for lines with several Western word spaces, these should be processed at the same time, with equal treatment. Each word space can be expanded to a maximum of 1/2&nbsp;em.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最大可以拉伸到半个汉字字宽。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">
-            西文詞距。一行內若有多處西文詞距，應該同時、同等量處理，每個西文詞距最大可以拉伸到半個漢字字寬。
-          </p>
-        </li>
-
-        <li>
-          <p its-locale-filter-list="en" lang="en" class="checkme">
-            Space between Han characters and Western texts can be expanded from the default width (e.g., 1/4&nbsp;em). They should be processed at the same time, with equal treatment.
-          </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            行内的中西间距，从默认宽度（如四分之一汉字宽）开始拉伸，一行内若有多处，应该同时、同等量处理，最大可拉大到半个汉字字宽。
-          </p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            行內的中西間距，從默認寬度（如四分之一漢字寬）開始拉伸，一行內若有多處，應該同時、同等量處理，最大可拉大到半個漢字字寬。
-          </p>
-          <aside class="note">
-            <p its-locale-filter-list="en" lang="en" class="checkme">
-              Numerous typesetting styles practically only allow expansion of space up to 1/3&nbsp;em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example 1/4&nbsp;em, in such cases, adjustments are not allowed.
-            </p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">
-              很多排版风格在实际处理上，只允许最大拉伸到三分之一汉字宽。与上述挤压处理一样，在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被拉伸。
-            </p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-              很多排版風格在實際處理上，只允許最大拉伸到三分之一漢字寬。與上述擠壓處理一樣，在一些排版風格中，中西間距固定默認寬度（如四分之壹漢字寬），被排除在行內調整對象之外，不允許被拉伸。
-            </p>
-          </aside>
-        </li>
-      </ol>
-
+    <ol type="a">
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          At the end of a line: adjusted to fixed 1/2&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          位于行末的标点。调成固定的半个汉字宽。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          位於行末的標點。調成固定的半個漢字寬。
+        </p>
+        <aside class="note">
           <p its-locale-filter-list="en" lang="en">
-            If all the aforementioned adjustments are not applicable, or the desired line length cannot be achieved, only the remaining inter-character spacing may be expanded at the same time, with equal treatment, to achieve text justification. However, there are two exceptions:
+            In Japanese texts, periods at the end of a line typically do not have their space reduced, but Chinese texts do. This is especially important in Mainland China where the <cite>General Rules for Punctuation</cite> (GB/T 15834—2011) defines in 5.1.10 that if a full-width punctuation occurs at the end of a line, it should take up 1/2&nbsp;em for a more pleasing aesthetic.
           </p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">
-            若上述所有项目均无法调整，或调整之后依旧无法达到预设行长，则只能针对剩余所有字符间距，进行同时、同等量拉伸，但是：
+            行末的句号，在日文排版中往往不进行挤压处理。但是对于中文排版，一般要进行处理，这对于中国大陆的排版规范尤其重要。《标点符号用法》（GB/T 15834—2011）有明确规定“5.1.10 标点符号排在一行末尾时，若为全角字符则应占半角字符的宽度（即半个字位置），以使视觉效果更美观。”
           </p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-            若上述所有項目均無法調整，或調整之後依舊無法達到預設行長，則只能針對剩餘所有字符間距，進行同時、同等量拉伸，但是：
+            行末的句號，在日文排版中往往不進行擠壓處理。但是對於中文排版，一般要進行處理，這對於中國大陸的排版規範尤其重要。《標點符號用法》（GB/T 15834—2011）有明確規定「5.1.10 標點符號排在一行末尾時，若為全形字符則應占半形字符的寬度（即半個字位置），以使視覺效果更美觀。」
           </p>
-          <ol type="a">
-            <li>
-              <p its-locale-filter-list="en" lang="en">
-                Spacing should not be added to characters stated in [[[#prohibition_rules_for_unbreakable_marks]]].
-              </p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">
-                禁止对[[[#prohibition_rules_for_unbreakable_marks]]]规定的字间距进行拉伸处理。
-              </p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-                禁止對[[[#prohibition_rules_for_unbreakable_marks]]]規定的字間距進行拉伸處理。
-              </p>
-            </li>
-            <li>
-              <p its-locale-filter-list="en" lang="en">
-                Avoid adding spacing to connector marks, solidi, and the characters immediately before and after these marks.
-              </p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">
-                避免对连接号、分隔号与其前后的字符进行拉伸处理。
-              </p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
-                避免對連接號、分隔號與其前後的字符進行拉伸處理。
-              </p>
-            </li>
-          </ol>
+        </aside>
+      </li>
 
-    </section>
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Spacing between Western text: for lines with numerous instances of Western text, their spacing should be processed at the same time, with equal treatment. The minimum space between each Western text should be 1/4&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          位于行内的西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最小可以挤压到四分之一汉字宽。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          位於行內的西文詞距。一行內若有多處西文詞距，應該同時、同等量處理，每個西文詞距最小可以擠壓到四分之一漢字寬。
+        </p>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Interpuncts: space reduction must take place equally on both sides of the character. The minimum space is 0, whereby the interpunct ends up being 1/2&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          位于行内的间隔号。挤压时必须同时从字面两侧、同等量处理，最小挤到0，即变成半个汉字字宽。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          位於行內的間隔號。擠壓時必須同時從字面兩側、同等量處理，最小擠到0，即變成半個漢字字寬。
+        </p>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Brackets: space reduction can take place before the opening bracket and after the closing bracket. If multiple brackets occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the bracket is 1/2&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          位于行内的夹注符号。可以对开始夹注符号的前侧、结束夹注符号的后侧进行挤压，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          位於行內的夾註符號。可以對開始夾註符號的前側、結束夾註符號的後側進行擠壓，最小可以擠壓到半個漢字字寬。壹行內如有多處，應該同時、同等量處理。
+        </p>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Commas, secondary commas and semi-colons: space reduction should follow [[[#h-punctuation_adjustment_space]]]. Spacing can be reduced at the end of the punctuation mark or equally on either side. If multiple of such punctuations occur within the same line, their space reduction should be processed at the same time, with equal treatment. Space can be reduced until the punctuation mark is 1/2&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          位于行内的逗号、顿号、分号。挤压空间依照[[[#h-punctuation_adjustment_space]]]，可以是后侧，也可以是字面两侧同时，最小可以挤压到半个汉字字宽。一行内如有多处，应该同时、同等量处理。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          位於行內的逗號、頓號、分號。擠壓空間依照[[[#h-punctuation_adjustment_space]]]，可以是後側，也可以是字面兩側同時，最小可以擠壓到半個漢字字寬。一行內如有多處，應該同時、同等量處理。
+        </p>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Spacing between Han characters and Western texts: if there are numerous instances of mixed texts, space reduction should be processed at the same time, with equal treatment, with the minimum space being 1/8&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          行内的中西间距，最小挤为八分之一汉字宽。一行内若有多处，应该同时、同等量处理。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          行內的中西間距，最小擠為八分之一漢字寬。一行內若有多處，應該同時、同等量處理。
+        </p>
+        <aside class="note">
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Certain typesetting styles have a fixed default spacing between Han characters and Western texts, for example 1/4&nbsp;em, in such cases, adjustment is not allowed.
+          </p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">
+            在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被挤压。
+          </p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+            在一些排版風格中，中西間距固定默認寬度（如四分之一漢字寬），被排除在行內調整對象之外，不允許被擠壓。
+          </p>
+        </aside>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Periods, question marks and exclamation marks: in accordance to [[[#h-punctuation_adjustment_space]]], if there is available space, spacing can be reduced up until the minimum size of 1/2&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          位于行内的句号、问号、感叹号。依照[[[#h-punctuation_adjustment_space]]]，如果有调整空间则可以挤压，最小挤为半个汉字字宽。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          位於行內的句號、問號、驚嘆號。依照[[[#h-punctuation_adjustment_space]]]，如果有調整空間則可以擠壓，最小擠為半個漢字字寬。
+        </p>
+        <aside class="note">
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            As these punctuation marks indicate a longer pause at the end of a sentence, certain typesetting styles do not allow line adjustment to be made on them, maintaining their width to be 1&nbsp;em.
+          </p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">
+            由于句末标点表示停顿较大，因此有些排版风格禁止此项调整，而保持句号、问号、感叹号固定一个字宽。
+          </p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+            由於句末標點表示停頓較大，因此有些排版風格禁止此項調整，而保持句號、問號、驚嘆號固定一個字寬。
+          </p>
+        </aside>
+      </li>
+    </ol>
+  </section>
+
+  <section id="procedures_for_inter-character_space_expansion">
+    <h4>
+      <span its-locale-filter-list="en" lang="en">Procedures for Inter-Character Space Expansion</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">拉伸处理的优先顺序</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">拉伸處理的優先順序</span>
+    </h4>
+
+    <p its-locale-filter-list="en" lang="en">
+      Inter-character space expansion should be processed according to the following steps, in order of precedence:
+    </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">
+      行内调整的拉伸处理，应该按照下述步骤，确定拉伸的优先顺序后依次进行处理：
+    </p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+      行內調整的拉伸處理，應該按照下述步驟，確定拉伸的優先順序後依次進行處理：
+    </p>
+
+    <ol type="a">
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Word spacing between Western text: for lines with several Western word spaces, these should be processed at the same time, with equal treatment. Each word space can be expanded to a maximum of 1/2&nbsp;em.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          西文词距。一行内若有多处西文词距，应该同时、同等量处理，每个西文词距最大可以拉伸到半个汉字字宽。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">
+          西文詞距。一行內若有多處西文詞距，應該同時、同等量處理，每個西文詞距最大可以拉伸到半個漢字字寬。
+        </p>
+      </li>
+
+      <li>
+        <p its-locale-filter-list="en" lang="en" class="checkme">
+          Space between Han characters and Western texts can be expanded from the default width (e.g., 1/4&nbsp;em). They should be processed at the same time, with equal treatment.
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          行内的中西间距，从默认宽度（如四分之一汉字宽）开始拉伸，一行内若有多处，应该同时、同等量处理，最大可拉大到半个汉字字宽。
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          行內的中西間距，從默認寬度（如四分之一漢字寬）開始拉伸，一行內若有多處，應該同時、同等量處理，最大可拉大到半個漢字字寬。
+        </p>
+        <aside class="note">
+          <p its-locale-filter-list="en" lang="en" class="checkme">
+            Numerous typesetting styles practically only allow expansion of space up to 1/3&nbsp;em. Similar to space reduction, there are certain typesetting styles where the spacing between Han characters and Western texts are fixed at a default width, for example 1/4&nbsp;em, in such cases, adjustments are not allowed.
+          </p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">
+            很多排版风格在实际处理上，只允许最大拉伸到三分之一汉字宽。与上述挤压处理一样，在一些排版风格中，中西间距固定默认宽度（如四分之一汉字宽），被排除在行内调整对象之外，不允许被拉伸。
+          </p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+            很多排版風格在實際處理上，只允許最大拉伸到三分之一漢字寬。與上述擠壓處理一樣，在一些排版風格中，中西間距固定默認寬度（如四分之壹漢字寬），被排除在行內調整對象之外，不允許被拉伸。
+          </p>
+        </aside>
+      </li>
+    </ol>
+
+        <p its-locale-filter-list="en" lang="en">
+          If all the aforementioned adjustments are not applicable, or the desired line length cannot be achieved, only the remaining inter-character spacing may be expanded at the same time, with equal treatment, to achieve text justification. However, there are two exceptions:
+        </p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          若上述所有项目均无法调整，或调整之后依旧无法达到预设行长，则只能针对剩余所有字符间距，进行同时、同等量拉伸，但是：
+        </p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+          若上述所有項目均無法調整，或調整之後依舊無法達到預設行長，則只能針對剩餘所有字符間距，進行同時、同等量拉伸，但是：
+        </p>
+        <ol type="a">
+          <li>
+            <p its-locale-filter-list="en" lang="en">
+              Spacing should not be added to characters stated in [[[#prohibition_rules_for_unbreakable_marks]]].
+            </p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">
+              禁止对[[[#prohibition_rules_for_unbreakable_marks]]]规定的字间距进行拉伸处理。
+            </p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+              禁止對[[[#prohibition_rules_for_unbreakable_marks]]]規定的字間距進行拉伸處理。
+            </p>
+          </li>
+          <li>
+            <p its-locale-filter-list="en" lang="en">
+              Avoid adding spacing to connector marks, solidi, and the characters immediately before and after these marks.
+            </p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">
+              避免对连接号、分隔号与其前后的字符进行拉伸处理。
+            </p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">
+              避免對連接號、分隔號與其前後的字符進行拉伸處理。
+            </p>
+          </li>
+        </ol>
 
   </section>
 
 </section>
+
+
+
+
+
 </section>
 
 
@@ -3154,8 +3079,8 @@ var respecConfig = {
 <section id="h_spacing">
   <h3>
     <span its-locale-filter-list="en" lang="en">Text spacing</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">文本的间距调整</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">文本的間距調整</span>
   </h3>
 
 
@@ -3420,6 +3345,24 @@ var respecConfig = {
         </ol>
       </section>
 </section>
+
+<section id="mixed_text_composition_in_horizontal_writing_mode">
+  <h4>
+    <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Horizontal Writing Mode</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">横排的中、西文混排配置</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
+  </h4>
+
+  <p its-locale-filter-list="en" lang="en">In horizontal writing mode, the basic approach uses proportional fonts to represent Western alphas and uses proportional or monospace fonts for <a href="#term.european-numerals" class="termref">European numerals</a>. In principle, there is tracking or spacing between an adjacent Han character and a Western character of up to 1/4&nbsp;em, except at the line start or end.</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时，西文字母使用比例字体；<a href="#term.european-numerals" class="termref">阿拉伯数字</a>则常用比例字体或等宽字体。原则上，汉字与西文字母、数字间使用不多于四分之一个汉字宽的字距或空白。但西文出现在行首或行尾时，则无须加入空白。</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時，西文字母使用比例字體；<a href="#term.european-numerals" class="termref">阿拉伯數字</a>則常用比例字體或等寬字體。原則上，漢字與西文字母、數字間使用不多於四分之一個漢字寬的字距或空白。但西文出現在行頭或行尾時，則毋須加入空白。</p>
+  <div class="note" id="n036">
+    <p its-locale-filter-list="en" lang="en">Another approach is to use a Western word space (<span class="uname" translate="no">U+0020 SPACE</span>), in which case the width depends on the font in use.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">或可使用西文词间空格（<span class="uname" translate="no">U+0020 SPACE</span> [ ]，其宽度随不同字体有所变化）。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">或可使用西文詞間空格（<span class="uname" translate="no">U+0020 SPACE</span> [ ]，其寬度隨不同字體有所變化）。</p>
+  </div>
+</section>
+
 </section>
 
 
@@ -3434,12 +3377,317 @@ var respecConfig = {
 <section id="h_baselines">
   <h2>
     <span its-locale-filter-list="en" lang="en">Baselines, line height, etc.</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">基线、行高等</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">基線、行高等</span>
+  </h2>
+
+<p>
+  TBD
+</p>
+
+
+</section>
+
+
+
+
+
+
+
+
+
+
+
+<!-- <section id="h_lists">
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Lists, counters, etc.</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">列表、计数器等</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">列表、計數器等</span>
+  </h3>
+
+<p>TBD(?)</p>
+</section> -->
+
+
+
+
+
+
+
+
+
+
+<!-- <section id="h_initials">
+  <h3>
+    <span its-locale-filter-list="en" lang="en">Styling initials</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">首字样式</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">首字樣式</span>
+  </h3>
+
+<p>TBD(?)</p>
+</section> -->
+
+</section>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<section id="h_page">
+  <h2>
+    <span its-locale-filter-list="en" lang="en">Page &amp; book layout</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">页面与书籍版式</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">頁面與書籍版式</span>
   </h2>
 
 
-<section id="considerations_in_designing_type_area">
+
+
+
+
+
+<section id="h_page_layout">
+  <h2>
+    <span its-locale-filter-list="en" lang="en">General page layout &amp; progression</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">基本页面版式与装订方向</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">基本頁面版式與裝訂方向</span>
+  </h2>
+
+
+<section id="page_design">
+    <h3>
+      <span its-locale-filter-list="en" lang="en">Page design</span>
+      <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版的页面设计</span>
+      <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版的頁面設計</span>
+    </h3>
+
+    <!-- oldid -->
+    <span id="type_area"></span>
+
+    <p its-locale-filter-list="en" lang="en">Books are usually designed in the following sequence.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">中文书籍排版依以下顺序设计：</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">中文書籍排版依以下順序設計：</p>
+
+    <ul>
+      <li id="id26">
+        <p its-locale-filter-list="en" lang="en">First, prepare a template of the <a href="#term.page-format" class="termref">page format</a>, which determines the basic appearance of document pages.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">首先，设计基本版式。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">首先，設計基本版式。</p>
+      </li>
+      <li id="id27">
+        <p its-locale-filter-list="en" lang="en"> Then, specify the details of actual page elements based on the template.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">其次，依照基本版式进行实际页面的设计。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">其次，依照基本版式進行實際頁面的設計。</p>
+      </li>
+    </ul>
+
+    <p its-locale-filter-list="en" lang="en">Books usually use one basic template for page format, whereas magazines often use several templates.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">书籍多数仅使用一种排版样式，杂志则会使用上数种。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">書籍多數僅使用一種排版樣式，雜誌則會使用上數種。</p>
+
+    <p its-locale-filter-list="en" lang="en" class="checkme">The <a href="#term.type-area" class="termref">type area</a>, sometimes called the printing area, is the rectangle in the middle of the page that contains the main body of the text. The text in the type area can be divided into two or more independent parts according to the reading direction of the text. Each independent part is called a "column", and this type of division is called a "multi-column layout".</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.type-area" class="termref">版心</a>是页面中间包含文本的主体的矩形区域。版心里的文字，可以按照文字阅读方向分割成两个或者更多的独立部分，每个独立部分称为“栏”，而这种分割版式叫“分栏”，根据一页里栏数，可以具体地称为“双栏”“三栏”等各种方式；相对地，将文字直接按照基本版式填满版心、不分栏的方式也可成为“通栏”。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.type-area" class="termref">版心</a>是頁面中間包含文本的主體的矩形區域。版心裏的文字，可以按照文字閱讀方向分割成兩個或者更多的獨立部分，每個獨立部分稱為「欄」，而這種分割版式叫「分欄」，根據一頁裏欄數，可以具體地稱為「雙欄」「三欄」等各種方式；相對地，將文字直接按照基本版式填滿版心、不分欄的方式也可成為「通欄」。</p>
+
+    <p its-locale-filter-list="en" lang="en" class="checkme">Although books tend to use one template for their page format, some further design effort will be needed to extend that template for pages such as the table of contents and indexes. Furthermore, there are many examples of indexes with a different page format than the basic page format, and vertically set books often have indexes in horizontal writing mode, and sometimes multiple columns. This still holds true where the goal is to make the size of the basic page template for indexes close to the size of basic page template in the basic page format.</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">尽管书籍通常仅使用一种排版样式（即“基本版式”），在实际页面的设计上，如目录、索引等页面，会基于基本版式重新设计。索引等页面采用不同排版样式设计的案例也相当多，直排书索引也会以横排或者多栏排版等方式设计。尽管如此，索引的版心尺寸仍应与基本版式近似。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">盡管書籍通常僅使用一種排版樣式（即“基本版式”），在實際頁面的設計上，如目錄、索引等頁面，會基於基本版式重新設計。索引等頁面採用不同排版樣式設計的案例也相當多，直排書索引也會以橫排或者多欄排版等方式設計。盡管如此，索引的版心尺寸仍應與基本版式近似。</p>
+    <p its-locale-filter-list="en" lang="en">Magazines usually contain various kinds of content, which naturally leads to a variety of template designs, different sizes of characters, and varying numbers of columns. </p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">杂志则因内容不同，排版样式多变，文字大小、栏数依照内容不同会有所变化。</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">雜誌則因內容不同，排版樣式多變，文字大小、欄數依照內容不同會有所變化。</p>
+
+    <section id="main_elements_of_basic_composition">
+      <h4>
+        <span its-locale-filter-list="en" lang="en">Basic Elements of Page Formatting</span>
+        <span its-locale-filter-list="zh-hans" lang="zh-hans">排版样式的主要元素</span>
+        <span its-locale-filter-list="zh-hant" lang="zh-hant">排版樣式的主要元素</span>
+      </h4>
+
+      <p its-locale-filter-list="en" lang="en">The following are the basic elements of a <a href="#term.page-format" class="termref">page format</a>.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.page-format" class="termref">排版样式</a>的主要元素如下：</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.page-format" class="termref">排版樣式</a>的主要元素如下：</p>
+      <ul>
+        <li id="id28">
+          <p its-locale-filter-list="en" lang="en">Trim size and binding side (vertically set Chinese documents are bound on the right-hand side, and horizontally set documents are bound on the left-hand side.)</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">完成尺寸与装订线（中文书籍直排为右侧装订、横排为左侧装订）</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">完成尺寸與裝訂邊（中文書籍直排為右側裝訂、橫排為左側裝訂）</p>
+        </li>
+        <li id="id29">
+          <p its-locale-filter-list="en" lang="en">Principal text direction (vertical writing mode or horizontal writing mode).</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">文本方向（直排或横排）</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">文本方向（直排或橫排）</p>
+        </li>
+        <li id="id30">
+          <p its-locale-filter-list="en" lang="en">Appearance of the type area and its position relative to the trim size.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式，及其与完成尺寸的相对位置</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式，及其與完成尺寸的相對位置</p>
+        </li>
+        <li id="id31">
+          <p its-locale-filter-list="en" lang="en"> Appearance of running heads and page numbers, and their positions relative to the trim size and type area.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">页眉与页码位置</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">頁眉與頁碼位置</p>
+        </li>
+      </ul>
+      <div class="note" id="n005">
+        <p its-locale-filter-list="en" lang="en">Establishing a type area may be seen as defining not only a rectangular area on a page, but also within that area, an underlying, logical grid to guide the placement of such things as characters, headings, and illustrations. In principle, the characters all align with the grid, and therefore, by default, the characters also align with the line start and end. However, when mixed with Western text or under [[[#prohibition_rules_for_line_start_end]]], the content may not be arranged according to the grid; however, the principle of aligning with the line start and line end must still be followed.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式设定步骤不仅是在页面中设定一个长方形空间，还需要为内文、标题、图片配置等做出一个基础的格子设定。于中文排版原则下，内文逐格进行配置，而得以对齐行首与行尾。但与西文混排、或配置<a href="#prohibition_rules_for_line_start_end">标点禁则</a>处理时，内文可不按照格子排列；但仍须遵守对齐行首行尾的原则。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式設定步驟不僅是在頁面中設定一個長方形空間，還需要為內文、標題、圖片配置等做出一個基礎的格子設定。於中文排版原則下，內文逐格進行配置，而得以對齊行首與行尾。但與西文混排、或配置<a href="#prohibition_rules_for_line_start_end">標點禁則</a>處理時，內文可不按照格子排列；但仍須遵守對齊行首行尾的原則。</p>
+      </div>
+    </section>
+
+
+    <section id="designing_elements_of_type_area">
+      <h4>
+        <span its-locale-filter-list="en" lang="en">Design of the Type Area</span>
+        <span its-locale-filter-list="zh-hans" lang="zh-hans">基本版式的设计元素</span>
+        <span its-locale-filter-list="zh-hant" lang="zh-hant">基本版式的設計元素</span>
+      </h4>
+
+      <p its-locale-filter-list="en" lang="en" class="checkme">The type area defines the basic printing style of a book. The following are the basic elements of the type area.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式的设计元素如下：</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式的設計元素如下：</p>
+      <ul>
+        <li id="id32">
+          <p its-locale-filter-list="en" lang="en"> Character size and typeface name</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">所使用的文字尺寸及字体种类</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">所使用的文字尺寸及字體種類</p>
+        </li>
+        <li id="id33">
+          <p its-locale-filter-list="en" lang="en"> Text direction (vertical writing mode or horizontal writing mode)</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">文本方向（直排或横排）</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">文本方向（直排或橫排）</p>
+        </li>
+        <li id="id34">
+          <p its-locale-filter-list="en" lang="en">Number of columns and column gap when using a multi-column format</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">分栏时，栏数以及栏距</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">分欄時，欄數以及欄距</p>
+        </li>
+        <li id="id35">
+          <p its-locale-filter-list="en" lang="en">Length of a line</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">一行的长度（字数）</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">一行的長度（字數）</p>
+        </li>
+        <li id="id36">
+          <p its-locale-filter-list="en" lang="en">Number of lines per page (number of lines per column when using a multi-column format)</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">一页的行数（分栏时为一栏的行数）</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">一頁的行數（分欄時為一欄的行數）</p>
+        </li>
+        <li id="id37">
+          <p its-locale-filter-list="en" lang="en"><a>Line gap</a></p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">行距</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">行距</p>
+        </li>
+        <li id="id38">
+          <p its-locale-filter-list="en" lang="en">Letter-spacing</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">字距</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">字距</p>
+        </li>
+      </ul>
+    </section>
+
+
+    <section id="using_type_area_for_composition_in_real_pages">
+      <h4>
+        <span its-locale-filter-list="en" lang="en">From the Template of the Page Format to the Actual Page Format</span>
+        <span its-locale-filter-list="zh-hans" lang="zh-hans">从基本版式到实际版面的定版设计</span>
+        <span its-locale-filter-list="zh-hant" lang="zh-hant">從基本版式到實際版面的定版設計</span>
+      </h4>
+
+      <p its-locale-filter-list="en" lang="en" class="checkme">This section explains how to create an actual page format based on the type area. </p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">本部分说明如何以基本版式为起点来为实际的各页面确定版式，这个步骤称做具体页面的“定版”。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本部分說明如何以基本版式為起點來為實際的各頁面確定版式，這個步驟稱做具體頁面的「定版」。</p>
+      <ol>
+        <li id="id39">
+          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Realm and position of headings:</span> The spacing of the heading in the block direction (i.e., height of the heading in horizontal writing mode or width of the heading in vertical writing mode) should be calculated from the position of the body text, and set to a multiple of the number of lines. If indent of the heading space is required, the starting point should be from the body text position set by the type area, and the amount of indent should be a multiple of the body text size.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">标题的地位：</span>标题摆放的位置及其所占空间，应以基本版式设定中行的位置为基准，以“占几行空间”方式来设计，这个方式称作“占行”。实际定版工作中为计算方便，通常设置为行的整数倍。定版要求通常写成“单行标题占三行”或“双行标题占五行”等方式，“单行”“双行”指标题文字本身的行数，而“三行”“五行”则指的是基本版式中行所占的空间。标题缩排时，也应以基本版式所设定的文字尺寸为基准，决定要缩排的量。具体方法可见[[[#handling_of_headings]]]。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">標題的地位：</span>標題擺放的位置及其所占空間，應以基本版式設定中行的位置為基準，以「占幾行空間」方式來設計，這個方式稱作「占行」。實際定版工作中為計算方便，通常設置為行的整數倍。定版要求通常寫成「單行標題占三行」或「雙行標題占五行」等方式，「單行」「雙行」指標題文字本身的行數，而「三行」「五行」則指的是基本版式中行所占的空間。標題縮排時，也應以基本版式所設定的文字尺寸為基準，決定要縮排的量。具體方法可見[[[#handling_of_headings]]]。</p>
+        </li>
+        <li id="id40">
+          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Size of illustrations:</span> In horizontal writing mode, the width of illustrations should, if at all possible, be the width of the type area; in horizontal writing mode with multiple columns, the width of illustrations should, if at all possible, be the width of one type area column. The illustrations are usually set at the head or the foot of the page. Likewise, in vertical writing mode, the height of illustrations should, if at all possible, be either the height of one type area column or the height of the type area. The illustrations are usually set at the right or left of the type area.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">图片的尺寸：</span>图片宽度尽可能地与基本版式中的版心宽度一致；若基本版式为分栏排版，则尽可能与基本版式所设定的栏宽（直排为栏高）一致。图片的摆放位置则多与版心的<a href="#term.top-margin" class="termref">天头</a>、<a href="#term.footer" class="termref">地脚</a>对齐。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">圖片的尺寸：</span>圖片寬度盡可能地與基本版式中的版心寬度一致；若基本版式為分欄排版，則盡可能與基本版式所設定的欄寬（直排為欄高）一致。圖片的擺放位置則多與版心的<a href="#term.top-margin" class="termref">天頭</a>、<a href="#term.footer" class="termref">地腳</a>對齊。</p>
+        </li>
+        <li id="id41">
+          <p its-locale-filter-list="en" lang="en"><span class="leadin">Pages for table of contents, index, and bibliography:</span> These pages’ layout is also based on the type area of body text. In practice, additional paddings might be attached onto the start and the end of the lines. Furthermore, these pages might be set in multiple columns while the body text is single column.</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">目录、索引、参考文献：</span>此类页面也以基本版式为基准进行排版。但具体实践中，行头、行尾常会添加额外留白；此外，在正文采用单栏排版的同时，此类页面也有可能分为多栏。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">目錄、索引、參考文獻：</span>此類頁面也以基本版式為基准進行排版。但具體實踐中，行頭、行尾常會添加額外留白；此外，在正文採用單欄排版的同時，此類頁面也有可能分為多欄。</p>
+        </li>
+      </ol>
+    </section>
+
+
+    <section id="procedure_for_defining_type_area">
+      <h4>
+        <span its-locale-filter-list="en" lang="en">Procedure for Defining the Type Area</span>
+        <span its-locale-filter-list="zh-hans" lang="zh-hans">设计基本版式的步骤</span>
+        <span its-locale-filter-list="zh-hant" lang="zh-hant">設計基本版式的步驟</span>
+      </h4>
+
+      <ol>
+        <li id="id42">
+          <p its-locale-filter-list="en" lang="en">Specifying the dimensions of the type area</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">决定版心尺寸</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">決定版心尺寸</p>
+          <ol>
+            <li id="id43">
+              <p its-locale-filter-list="en" lang="en">For a document with a single column per page, specify the character size, the line length (the number of characters per line), the number of lines per page, and the <a>line gap</a>. </p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">无分栏时，需决定文字尺寸、一行的字数（即行长）、一页的行数以及行距。</p>
+              <p its-locale-filter-list="zh-hant" lang="zh-hant">無分欄時，需決定文字尺寸、一行的字數（即行長）、一頁的行數以及行距。</p>
+            </li>
+            <li id="id44">
+              <p its-locale-filter-list="en" lang="en">For a document with multiple columns per page, specify the character size, the line length (the number of characters per line), the number of lines per column, the <a>line gap</a>, the number of columns and the column gap.</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">当分栏时，需决定文字尺寸、一行的字数（即行长）、一栏的行数、行距、栏数以及栏距。</p>
+              <p its-locale-filter-list="zh-hant" lang="zh-hant">當分欄時，需決定文字尺寸、一行的字數（即行長）、一欄的行數、行距、欄數以及欄距。</p>
+            </li>
+          </ol>
+        </li>
+        <li id="id45">
+          <p its-locale-filter-list="en" lang="en">For determining the position of the type area relative to the trim size, there are various alternative methods available:</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">决定相对于完成尺寸，版心的配置位置。版心配置位置的设计顺序有着以下方式。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant">決定相對於完成尺寸，版心的配置位置。版心配置位置的設計順序有著以下方式。</p>
+          <ol>
+            <li id="id46">
+              <p its-locale-filter-list="en" lang="en"> Set the type area at the horizontal and vertical center of the trim size.</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">将版心置于完成尺寸的正中央，天地等高、左右等宽。</p>
+              <p its-locale-filter-list="zh-hant" lang="zh-hant">將版心置於完成尺寸的正中央，天地等高、左右等寬。</p>
+            </li>
+            <li id="id47">
+              <p its-locale-filter-list="en" lang="en"> Position vertically by specifying the size of the space at the head (for horizontal writing mode) or the space at the foot (for vertical writing mode). Position horizontally by centering the type area.</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时指定天的留白量、直排时则指定地的留白量，左右等宽。</p>
+              <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時指定天的留白量、直排時則指定地的留白量，左右等寬。</p>
+            </li>
+            <li id="id48">
+              <p its-locale-filter-list="en" lang="en"> Position vertically by centering the type area. Position horizontally by specifying the size of the space for the gutter.</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">天地等高，指定装订线的留白量。</p>
+              <p its-locale-filter-list="zh-hant" lang="zh-hant">天地等高，指定裝訂邊的留白量。</p>
+            </li>
+            <li id="id49">
+              <p its-locale-filter-list="en" lang="en"> Position vertically by specifying the space at the head (for horizontal writing mode) or the space at the foot (for vertical writing mode). Position horizontally by specifying the size of the space for the gutter.</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">指定装订线的留白量，横排时指定天的留白量、直排时则指定地的留白量。</p>
+              <p its-locale-filter-list="zh-hant" lang="zh-hant">指定裝訂邊的留白量，橫排時指定天的留白量、直排時則指定地的留白量。</p>
+            </li>
+          </ol>
+        </li>
+      </ol>
+      <div class="note" id="n006">
+        <p its-locale-filter-list="en" lang="en">In most cases the type area is set at the horizontal and vertical center of the trim size, and can then be adjusted depending on its dimensions. This design method is mainly inherited from letterpress printing technology. For desktop publishing, the dimensions of the type area are usually calculated based on the space between the type area and the trim size.</p>
+        <p its-locale-filter-list="zh-hans" lang="zh-hans">一般而言，版心多置于完成尺寸的的正中央，后依照版心尺寸不同，向上下、左右调整。这种设计方式主要承袭自活字印刷，但在桌面排版中，则多以完成尺寸计算与版心尺寸四方边界之差为之。</p>
+        <p its-locale-filter-list="zh-hant" lang="zh-hant">一般而言，版心多置於完成尺寸的的正中央，後依照版心尺寸不同，向上下、左右調整。這種設計方式主要承襲自活字印刷，但在桌面排版中，則多以完成尺寸計算與版心尺寸四方邊界之差為之。</p>
+      </div>
+    </section>
+
+
+    <section id="considerations_in_designing_type_area">
       <h4>
         <span its-locale-filter-list="en" lang="en">Considerations when Designing the Type Area</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">基本版式设计的注意事项</span>
@@ -3708,305 +3956,6 @@ var respecConfig = {
           </div>
         </li>
       </ol>
-    </section>
-
-</section>
-
-
-
-
-
-
-
-
-
-
-
-<section id="h_lists">
-  <h3>
-    <span its-locale-filter-list="en" lang="en">Lists, counters, etc.</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h3>
-
-<p>TBD(?)</p>
-</section>
-
-
-
-
-
-
-
-
-
-
-<section id="h_initials">
-  <h3>
-    <span its-locale-filter-list="en" lang="en">Styling initials</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h3>
-
-<p>TBD(?)</p>
-</section>
-</section>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<section id="h_page">
-  <h2>
-    <span its-locale-filter-list="en" lang="en">Page &amp; book layout</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h2>
-
-  
-
-
-  
-
-
-<section id="h_page_layout">
-  <h2>
-    <span its-locale-filter-list="en" lang="en">General page layout &amp; progression</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">翻译我</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">翻译我</span>
-  </h2>
-
-  
-<section id="page_design">
-    <h3>
-      <span its-locale-filter-list="en" lang="en">Page design</span>
-      <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版的页面设计</span>
-      <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版的頁面設計</span>
-    </h3>
-
-    <!-- oldid -->
-    <span id="type_area"></span>
-
-    <p its-locale-filter-list="en" lang="en">Books are usually designed in the following sequence.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">中文书籍排版依以下顺序设计：</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">中文書籍排版依以下順序設計：</p>
-
-    <ul>
-      <li id="id26">
-        <p its-locale-filter-list="en" lang="en">First, prepare a template of the <a href="#term.page-format" class="termref">page format</a>, which determines the basic appearance of document pages.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">首先，设计基本版式。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">首先，設計基本版式。</p>
-      </li>
-      <li id="id27">
-        <p its-locale-filter-list="en" lang="en"> Then, specify the details of actual page elements based on the template.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">其次，依照基本版式进行实际页面的设计。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">其次，依照基本版式進行實際頁面的設計。</p>
-      </li>
-    </ul>
-
-    <p its-locale-filter-list="en" lang="en">Books usually use one basic template for page format, whereas magazines often use several templates.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">书籍多数仅使用一种排版样式，杂志则会使用上数种。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">書籍多數僅使用一種排版樣式，雜誌則會使用上數種。</p>
-
-    <p its-locale-filter-list="en" lang="en" class="checkme">The <a href="#term.type-area" class="termref">type area</a>, sometimes called the printing area, is the rectangle in the middle of the page that contains the main body of the text. The text in the type area can be divided into two or more independent parts according to the reading direction of the text. Each independent part is called a "column", and this type of division is called a "multi-column layout".</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.type-area" class="termref">版心</a>是页面中间包含文本的主体的矩形区域。版心里的文字，可以按照文字阅读方向分割成两个或者更多的独立部分，每个独立部分称为“栏”，而这种分割版式叫“分栏”，根据一页里栏数，可以具体地称为“双栏”“三栏”等各种方式；相对地，将文字直接按照基本版式填满版心、不分栏的方式也可成为“通栏”。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.type-area" class="termref">版心</a>是頁面中間包含文本的主體的矩形區域。版心裏的文字，可以按照文字閱讀方向分割成兩個或者更多的獨立部分，每個獨立部分稱為「欄」，而這種分割版式叫「分欄」，根據一頁裏欄數，可以具體地稱為「雙欄」「三欄」等各種方式；相對地，將文字直接按照基本版式填滿版心、不分欄的方式也可成為「通欄」。</p>
-
-    <p its-locale-filter-list="en" lang="en" class="checkme">Although books tend to use one template for their page format, some further design effort will be needed to extend that template for pages such as the table of contents and indexes. Furthermore, there are many examples of indexes with a different page format than the basic page format, and vertically set books often have indexes in horizontal writing mode, and sometimes multiple columns. This still holds true where the goal is to make the size of the basic page template for indexes close to the size of basic page template in the basic page format.</p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">尽管书籍通常仅使用一种排版样式（即“基本版式”），在实际页面的设计上，如目录、索引等页面，会基于基本版式重新设计。索引等页面采用不同排版样式设计的案例也相当多，直排书索引也会以横排或者多栏排版等方式设计。尽管如此，索引的版心尺寸仍应与基本版式近似。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">盡管書籍通常僅使用一種排版樣式（即“基本版式”），在實際頁面的設計上，如目錄、索引等頁面，會基於基本版式重新設計。索引等頁面採用不同排版樣式設計的案例也相當多，直排書索引也會以橫排或者多欄排版等方式設計。盡管如此，索引的版心尺寸仍應與基本版式近似。</p>
-    <p its-locale-filter-list="en" lang="en">Magazines usually contain various kinds of content, which naturally leads to a variety of template designs, different sizes of characters, and varying numbers of columns. </p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">杂志则因内容不同，排版样式多变，文字大小、栏数依照内容不同会有所变化。</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">雜誌則因內容不同，排版樣式多變，文字大小、欄數依照內容不同會有所變化。</p>
-
-    <section id="main_elements_of_basic_composition">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Basic Elements of Page Formatting</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">排版样式的主要元素</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">排版樣式的主要元素</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en">The following are the basic elements of a <a href="#term.page-format" class="termref">page format</a>.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.page-format" class="termref">排版样式</a>的主要元素如下：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.page-format" class="termref">排版樣式</a>的主要元素如下：</p>
-      <ul>
-        <li id="id28">
-          <p its-locale-filter-list="en" lang="en">Trim size and binding side (vertically set Chinese documents are bound on the right-hand side, and horizontally set documents are bound on the left-hand side.)</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">完成尺寸与装订线（中文书籍直排为右侧装订、横排为左侧装订）</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">完成尺寸與裝訂邊（中文書籍直排為右側裝訂、橫排為左側裝訂）</p>
-        </li>
-        <li id="id29">
-          <p its-locale-filter-list="en" lang="en">Principal text direction (vertical writing mode or horizontal writing mode).</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">文字书写方向（直排或横排）</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">文字書寫方向（直排或橫排）</p>
-        </li>
-        <li id="id30">
-          <p its-locale-filter-list="en" lang="en">Appearance of the type area and its position relative to the trim size.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式，及其与完成尺寸的相对位置</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式，及其與完成尺寸的相對位置</p>
-        </li>
-        <li id="id31">
-          <p its-locale-filter-list="en" lang="en"> Appearance of running heads and page numbers, and their positions relative to the trim size and type area.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">页眉与页码位置</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">頁眉與頁碼位置</p>
-        </li>
-      </ul>
-      <div class="note" id="n005">
-        <p its-locale-filter-list="en" lang="en">Establishing a type area may be seen as defining not only a rectangular area on a page, but also within that area, an underlying, logical grid to guide the placement of such things as characters, headings, and illustrations. In principle, the characters all align with the grid, and therefore, by default, the characters also align with the line start and end. However, when mixed with Western text or under [[[#prohibition_rules_for_line_start_end]]], the content may not be arranged according to the grid; however, the principle of aligning with the line start and line end must still be followed.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式设定步骤不仅是在页面中设定一个长方形空间，还需要为内文、标题、图片配置等做出一个基础的格子设定。于中文排版原则下，内文逐格进行配置，而得以对齐行首与行尾。但与西文混排、或配置<a href="#prohibition_rules_for_line_start_end">标点禁则</a>处理时，内文可不按照格子排列；但仍须遵守对齐行首行尾的原则。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式設定步驟不僅是在頁面中設定一個長方形空間，還需要為內文、標題、圖片配置等做出一個基礎的格子設定。於中文排版原則下，內文逐格進行配置，而得以對齊行首與行尾。但與西文混排、或配置<a href="#prohibition_rules_for_line_start_end">標點禁則</a>處理時，內文可不按照格子排列；但仍須遵守對齊行首行尾的原則。</p>
-      </div>
-    </section>
-
-
-    <section id="designing_elements_of_type_area">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Design of the Type Area</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">基本版式的设计元素</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">基本版式的設計元素</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en" class="checkme">The type area defines the basic printing style of a book. The following are the basic elements of the type area.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">基本版式的设计元素如下：</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant">基本版式的設計元素如下：</p>
-      <ul>
-        <li id="id32">
-          <p its-locale-filter-list="en" lang="en"> Character size and typeface name</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">所使用的文字尺寸及字体种类</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">所使用的文字尺寸及字體種類</p>
-        </li>
-        <li id="id33">
-          <p its-locale-filter-list="en" lang="en"> Text direction (vertical writing mode or horizontal writing mode)</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">文字书写方向（直排或横排）</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">文字書寫方向（直排或橫排）</p>
-        </li>
-        <li id="id34">
-          <p its-locale-filter-list="en" lang="en">Number of columns and column gap when using a multi-column format</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">分栏时，栏数以及栏距</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">分欄時，欄數以及欄距</p>
-        </li>
-        <li id="id35">
-          <p its-locale-filter-list="en" lang="en">Length of a line</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">一行的长度（字数）</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">一行的長度（字數）</p>
-        </li>
-        <li id="id36">
-          <p its-locale-filter-list="en" lang="en">Number of lines per page (number of lines per column when using a multi-column format)</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">一页的行数（分栏时为一栏的行数）</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">一頁的行數（分欄時為一欄的行數）</p>
-        </li>
-        <li id="id37">
-          <p its-locale-filter-list="en" lang="en"><a>Line gap</a></p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">行距</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">行距</p>
-        </li>
-        <li id="id38">
-          <p its-locale-filter-list="en" lang="en">Letter-spacing</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">字距</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">字距</p>
-        </li>
-      </ul>
-    </section>
-
-
-    <section id="using_type_area_for_composition_in_real_pages">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">From the Template of the Page Format to the Actual Page Format</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">从基本版式到实际版面的定版设计</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">從基本版式到實際版面的定版設計</span>
-      </h4>
-
-      <p its-locale-filter-list="en" lang="en" class="checkme">This section explains how to create an actual page format based on the type area. </p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans">本部分说明如何以基本版式为起点来为实际的各页面确定版式，这个步骤称做具体页面的“定版”。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本部分說明如何以基本版式為起點來為實際的各頁面確定版式，這個步驟稱做具體頁面的「定版」。</p>
-      <ol>
-        <li id="id39">
-          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Realm and position of headings:</span> The spacing of the heading in the block direction (i.e., height of the heading in horizontal writing mode or width of the heading in vertical writing mode) should be calculated from the position of the body text, and set to a multiple of the number of lines. If indent of the heading space is required, the starting point should be from the body text position set by the type area, and the amount of indent should be a multiple of the body text size.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">标题的地位：</span>标题摆放的位置及其所占空间，应以基本版式设定中行的位置为基准，以“占几行空间”方式来设计，这个方式称作“占行”。实际定版工作中为计算方便，通常设置为行的整数倍。定版要求通常写成“单行标题占三行”或“双行标题占五行”等方式，“单行”“双行”指标题文字本身的行数，而“三行”“五行”则指的是基本版式中行所占的空间。标题缩排时，也应以基本版式所设定的文字尺寸为基准，决定要缩排的量。具体方法可见[[[#handling_of_headings]]]。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">標題的地位：</span>標題擺放的位置及其所占空間，應以基本版式設定中行的位置為基準，以「占幾行空間」方式來設計，這個方式稱作「占行」。實際定版工作中為計算方便，通常設置為行的整數倍。定版要求通常寫成「單行標題占三行」或「雙行標題占五行」等方式，「單行」「雙行」指標題文字本身的行數，而「三行」「五行」則指的是基本版式中行所占的空間。標題縮排時，也應以基本版式所設定的文字尺寸為基準，決定要縮排的量。具體方法可見[[[#handling_of_headings]]]。</p>
-        </li>
-        <li id="id40">
-          <p its-locale-filter-list="en" lang="en" class="checkme"><span class="leadin">Size of illustrations:</span> In horizontal writing mode, the width of illustrations should, if at all possible, be the width of the type area; in horizontal writing mode with multiple columns, the width of illustrations should, if at all possible, be the width of one type area column. The illustrations are usually set at the head or the foot of the page. Likewise, in vertical writing mode, the height of illustrations should, if at all possible, be either the height of one type area column or the height of the type area. The illustrations are usually set at the right or left of the type area.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">图片的尺寸：</span>图片宽度尽可能地与基本版式中的版心宽度一致；若基本版式为分栏排版，则尽可能与基本版式所设定的栏宽（直排为栏高）一致。图片的摆放位置则多与版心的<a href="#term.top-margin" class="termref">天头</a>、<a href="#term.footer" class="termref">地脚</a>对齐。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">圖片的尺寸：</span>圖片寬度盡可能地與基本版式中的版心寬度一致；若基本版式為分欄排版，則盡可能與基本版式所設定的欄寬（直排為欄高）一致。圖片的擺放位置則多與版心的<a href="#term.top-margin" class="termref">天頭</a>、<a href="#term.footer" class="termref">地腳</a>對齊。</p>
-        </li>
-        <li id="id41">
-          <p its-locale-filter-list="en" lang="en"><span class="leadin">Pages for table of contents, index, and bibliography:</span> These pages’ layout is also based on the type area of body text. In practice, additional paddings might be attached onto the start and the end of the lines. Furthermore, these pages might be set in multiple columns while the body text is single column.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">目录、索引、参考文献：</span>此类页面也以基本版式为基准进行排版。但具体实践中，行头、行尾常会添加额外留白；此外，在正文采用单栏排版的同时，此类页面也有可能分为多栏。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme"><span class="leadin">目錄、索引、參考文獻：</span>此類頁面也以基本版式為基准進行排版。但具體實踐中，行頭、行尾常會添加額外留白；此外，在正文採用單欄排版的同時，此類頁面也有可能分為多欄。</p>
-        </li>
-      </ol>
-    </section>
-
-
-    <section id="procedure_for_defining_type_area">
-      <h4>
-        <span its-locale-filter-list="en" lang="en">Procedure for Defining the Type Area</span>
-        <span its-locale-filter-list="zh-hans" lang="zh-hans">设计基本版式的步骤</span>
-        <span its-locale-filter-list="zh-hant" lang="zh-hant">設計基本版式的步驟</span>
-      </h4>
-
-      <ol>
-        <li id="id42">
-          <p its-locale-filter-list="en" lang="en">Specifying the dimensions of the type area</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">决定版心尺寸</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">決定版心尺寸</p>
-          <ol>
-            <li id="id43">
-              <p its-locale-filter-list="en" lang="en">For a document with a single column per page, specify the character size, the line length (the number of characters per line), the number of lines per page, and the <a>line gap</a>. </p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">无分栏时，需决定文字尺寸、一行的字数（即行长）、一页的行数以及行距。</p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant">無分欄時，需決定文字尺寸、一行的字數（即行長）、一頁的行數以及行距。</p>
-            </li>
-            <li id="id44">
-              <p its-locale-filter-list="en" lang="en">For a document with multiple columns per page, specify the character size, the line length (the number of characters per line), the number of lines per column, the <a>line gap</a>, the number of columns and the column gap.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">当分栏时，需决定文字尺寸、一行的字数（即行长）、一栏的行数、行距、栏数以及栏距。</p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant">當分欄時，需決定文字尺寸、一行的字數（即行長）、一欄的行數、行距、欄數以及欄距。</p>
-            </li>
-          </ol>
-        </li>
-        <li id="id45">
-          <p its-locale-filter-list="en" lang="en">For determining the position of the type area relative to the trim size, there are various alternative methods available:</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">决定相对于完成尺寸，版心的配置位置。版心配置位置的设计顺序有着以下方式。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant">決定相對於完成尺寸，版心的配置位置。版心配置位置的設計順序有著以下方式。</p>
-          <ol>
-            <li id="id46">
-              <p its-locale-filter-list="en" lang="en"> Set the type area at the horizontal and vertical center of the trim size.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">将版心置于完成尺寸的正中央，天地等高、左右等宽。</p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant">將版心置於完成尺寸的正中央，天地等高、左右等寬。</p>
-            </li>
-            <li id="id47">
-              <p its-locale-filter-list="en" lang="en"> Position vertically by specifying the size of the space at the head (for horizontal writing mode) or the space at the foot (for vertical writing mode). Position horizontally by centering the type area.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">横排时指定天的留白量、直排时则指定地的留白量，左右等宽。</p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant">橫排時指定天的留白量、直排時則指定地的留白量，左右等寬。</p>
-            </li>
-            <li id="id48">
-              <p its-locale-filter-list="en" lang="en"> Position vertically by centering the type area. Position horizontally by specifying the size of the space for the gutter.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">天地等高，指定装订线的留白量。</p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant">天地等高，指定裝訂邊的留白量。</p>
-            </li>
-            <li id="id49">
-              <p its-locale-filter-list="en" lang="en"> Position vertically by specifying the space at the head (for horizontal writing mode) or the space at the foot (for vertical writing mode). Position horizontally by specifying the size of the space for the gutter.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">指定装订线的留白量，横排时指定天的留白量、直排时则指定地的留白量。</p>
-              <p its-locale-filter-list="zh-hant" lang="zh-hant">指定裝訂邊的留白量，橫排時指定天的留白量、直排時則指定地的留白量。</p>
-            </li>
-          </ol>
-        </li>
-      </ol>
-      <div class="note" id="n006">
-        <p its-locale-filter-list="en" lang="en">In most cases the type area is set at the horizontal and vertical center of the trim size, and can then be adjusted depending on its dimensions. This design method is mainly inherited from letterpress printing technology. For desktop publishing, the dimensions of the type area are usually calculated based on the space between the type area and the trim size.</p>
-        <p its-locale-filter-list="zh-hans" lang="zh-hans">一般而言，版心多置于完成尺寸的的正中央，后依照版心尺寸不同，向上下、左右调整。这种设计方式主要承袭自活字印刷，但在桌面排版中，则多以完成尺寸计算与版心尺寸四方边界之差为之。</p>
-        <p its-locale-filter-list="zh-hant" lang="zh-hant">一般而言，版心多置於完成尺寸的的正中央，後依照版心尺寸不同，向上下、左右調整。這種設計方式主要承襲自活字印刷，但在桌面排版中，則多以完成尺寸計算與版心尺寸四方邊界之差為之。</p>
-      </div>
     </section>
   </section>
 
@@ -4378,16 +4327,13 @@ var respecConfig = {
 <section id="h_interaction">
   <h2>
     <span its-locale-filter-list="en" lang="en">Forms &amp; user interaction</span>
-    <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版基础</span>
-    <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版基礎</span>
+    <span its-locale-filter-list="zh-hans" lang="zh-hans">表单与用户交互</span>
+    <span its-locale-filter-list="zh-hant" lang="zh-hant">表單與用戶交互</span>
   </h2>
 
-  
+
 </section>
 
-FINDME
-
-<!--   END OF NEW -->
 
 
 
@@ -6349,6 +6295,7 @@ FINDME
   <p its-locale-filter-list="zh-hans" lang="zh-hans">对上一次发布进行了如下变更：</p>
   <p its-locale-filter-list="zh-hant" lang="zh-hant">對上一次發佈進行了如下變更：</p>
   <ul>
+    <li>Reorganise the clreq content to fit around the standardised headings used for the Script Resources and Gap Analysis, etc. documents.</li>
     <li>Various editorial and formatting fixes and translation improvements.</li>
   </ul>
   <p its-locale-filter-list="en" lang="en">A detailed list of changes, including diffs, can be found in the <a href="https://github.com/w3c/clreq/commits/gh-pages">github commit log</a>.</p>

--- a/indexNEW.html
+++ b/indexNEW.html
@@ -131,7 +131,7 @@ var respecConfig = {
 
   <section id="basic_features_of_chinese_script">
     <h3>
-      <span its-locale-filter-list="en" lang="en">Basic Features of Chinese Script</span>
+      <span its-locale-filter-list="en" lang="en">Basic features of Chinese script</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版的主要特色</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版的主要特色</span>
     </h3>
@@ -182,14 +182,14 @@ var respecConfig = {
 
   <section id="basic_principles_for_development_of_this_document">
     <h3>
-      <span its-locale-filter-list="en" lang="en">How This Document Was Created</span>
+      <span its-locale-filter-list="en" lang="en">How this document was created</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">撰写方针</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">撰寫方針</span>
     </h3>
 
     <section id="chinese_text_in_this_document">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Languages Used in this Document</span>
+        <span its-locale-filter-list="en" lang="en">Languages used in this document</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">本文档所使用的中文语言</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">本文檔所使用的中文語言</span>
       </h4>
@@ -205,7 +205,7 @@ var respecConfig = {
 
     <section id="design_approach">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Design Approach</span>
+        <span its-locale-filter-list="en" lang="en">Design approach</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">设计原则</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">設計原則</span>
       </h4>
@@ -287,7 +287,7 @@ var respecConfig = {
 
 <section id="writing_modes_in_chinese_composition">
   <h4>
-  <span its-locale-filter-list="en" lang="en">Writing Modes in Chinese</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中文的行文模式</span>
+  <span its-locale-filter-list="en" lang="en">Writing modes in Chinese</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中文的行文模式</span>
   <span its-locale-filter-list="zh-hant" lang="zh-hant">中文的行文模式</span>
   </h4>
 
@@ -314,7 +314,7 @@ var respecConfig = {
 </div>
 </section>
 <section id="major_differences_between_horizontal_and_vertical_writing_modes">
-<h4> <span its-locale-filter-list="en" lang="en">Major Differences Between Horizontal and Vertical Writing Modes</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">横排与直排的主要差异点</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排與直排的主要差異點</span> </h4>
+<h4> <span its-locale-filter-list="en" lang="en">Major differences between horizontal and vertical writing modes</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">横排与直排的主要差异点</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排與直排的主要差異點</span> </h4>
 <p its-locale-filter-list="en" lang="en">The following are the major differences between vertical writing mode and horizontal writing mode:</p>
 <p its-locale-filter-list="zh-hans" lang="zh-hans">直排与横排的主要差异点，列举如下：</p>
 <p its-locale-filter-list="zh-hant" lang="zh-hant">直排與橫排的主要差異點，列舉如下：</p>
@@ -534,7 +534,7 @@ var respecConfig = {
 
 <section id="mixed_text_composition_in_vertical_writing_mode">
   <h4>
-    <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Vertical Writing Mode</span>
+    <span its-locale-filter-list="en" lang="en">Mixed text composition in vertical writing mode</span>
     <span its-locale-filter-list="zh-hans" lang="zh-hans">直排的中、西文混排配置</span>
     <span its-locale-filter-list="zh-hant" lang="zh-hant">直排的中、西文混排配置</span>
   </h4>
@@ -655,7 +655,7 @@ var respecConfig = {
 
     <section id="four_commonly_used_typefaces_for_chinese_composition">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Four frequently-used Typefaces for Chinese Text</span>
+        <span its-locale-filter-list="en" lang="en">Four frequently-used typefaces for Chinese text</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">中文排版经常使用的四种字体</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">中文排版經常使用的四種字體</span>
       </h4>
@@ -1421,7 +1421,7 @@ var respecConfig = {
 
   <section id="id84">
     <h2>
-      <span its-locale-filter-list="en" lang="en">Emphasis Dots</span>
+      <span its-locale-filter-list="en" lang="en">Emphasis dots</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">着重号</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">着重號</span>
     </h2>
@@ -1507,7 +1507,7 @@ var respecConfig = {
 
     <section id="usage_of_interlinear_annotations">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Usage of Interlinear Annotations</span>
+        <span its-locale-filter-list="en" lang="en">Usage of interlinear annotations</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行间注的用途</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間注的用途</span>
       </h4>
@@ -1517,7 +1517,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.interlinear-annotations" class="termref">行間注</a>是標注於字詞旁側的小字號補充文本。行間注的注文通常位於行間，與其所標注的基文對齊，因這一性質而又名為行間注。行間注在中文排版里的用途主要為標音與釋義。</p>
       <section id="h-indicating_pronunciation_for_chinese_characters">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Indicating the Pronunciation for Han characters</span>
+          <span its-locale-filter-list="en" lang="en">Indicating the pronunciation for Han characters</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">为汉字标注读音</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">為漢字標注讀音</span>
         </h5>
@@ -1562,7 +1562,7 @@ var respecConfig = {
 
       <section id="h-indicating_meaning_or_other_information">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Indicating Meaning or Other Additional Information</span>
+          <span its-locale-filter-list="en" lang="en">Indicating meaning or other additional information</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">标注释义等非语音信息</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標注釋義等非語音信息</span>
         </h5>
@@ -1596,7 +1596,7 @@ var respecConfig = {
 
     <section id="overview_of_positioning_of_interlinear_annotations">
       <h3>
-        <span its-locale-filter-list="en" lang="en">Overview of Interlinear Annotation Positioning</span>
+        <span its-locale-filter-list="en" lang="en">Overview of interlinear annotation positioning</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行间注排版概述</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間注排版概述</span>
       </h3>
@@ -1618,14 +1618,14 @@ var respecConfig = {
 
     <section id="positioning_of_zhuyin">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Positioning of Bopomofo Interlinear Annotations</span>
+        <span its-locale-filter-list="en" lang="en">Positioning of Bopomofo interlinear annotations</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号标音的排版</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號標音的排版</span>
       </h4>
 
       <section id="h-positioning_zhuyin_symbols">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Positioning of Bopomofo Symbols</span>
+          <span its-locale-filter-list="en" lang="en">Positioning of Bopomofo symbols</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号的位置</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號的位置</span>
         </h5>
@@ -1638,7 +1638,7 @@ var respecConfig = {
 
       <section id="h-choice_of_size_and_ratio_for_zhuyin">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Choice of Size and Ratio for Bopomofo Symbols</span>
+          <span its-locale-filter-list="en" lang="en">Choice of size and ratio for Bopomofo symbols</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号的比例与大小</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號的比例與大小</span>
         </h5>
@@ -1693,7 +1693,7 @@ var respecConfig = {
 
       <section id="h-positioning_tones_in_zhuyin">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Positioning of the Tones in Bopomofo Symbols</span>
+          <span its-locale-filter-list="en" lang="en">Positioning of the tones in Bopomofo symbols</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号的声调号位置</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號的聲調號位置</span>
         </h5>
@@ -1786,7 +1786,7 @@ var respecConfig = {
 
       <section id="h-line_prohibition_rules_for_zhuyin">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Line Prohibition Rules for Bopomofo</span>
+          <span its-locale-filter-list="en" lang="en">Line prohibition rules for Bopomofo</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">注音标音分离禁则</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">注音標音分離禁則</span>
         </h5>
@@ -1802,14 +1802,14 @@ var respecConfig = {
 
     <section id="positioning_of_romanization">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Positioning of Romanized Interlinear Annotations</span>
+        <span its-locale-filter-list="en" lang="en">Positioning of Romanized interlinear annotations</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">罗马拼音标音的排版</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">羅馬拼音標音的排版</span>
       </h4>
 
       <section id="h-basic-requirements">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Basic Requirements</span>
+          <span its-locale-filter-list="en" lang="en">Basic requirements</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">基本规则</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">基本規則</span>
         </h5>
@@ -1940,7 +1940,7 @@ var respecConfig = {
 
     <section id="atypical_cases_for_chinese_phonetic_annotations">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Atypical Cases for Han character Phonetic Annotations</span>
+        <span its-locale-filter-list="en" lang="en">Atypical cases for Han character phonetic annotations</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">汉字标音的非典型情况</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">漢字標音的非典型情況</span>
       </h4>
@@ -1965,7 +1965,7 @@ var respecConfig = {
 
     <section id="positioning_of_bilingual_annotations">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Positioning of Bilingual Annotations</span>
+        <span its-locale-filter-list="en" lang="en">Positioning of bilingual annotations</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">中外文对照的排版</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">中外文對照的排版</span>
       </h4>
@@ -1976,7 +1976,7 @@ var respecConfig = {
 
       <section id="h-word_alignment">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Word Alignment</span>
+          <span its-locale-filter-list="en" lang="en">Word alignment</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">词的对齐</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">詞的對齊</span>
         </h5>
@@ -2004,7 +2004,7 @@ var respecConfig = {
 
     <section id="positioning_of_interlinear_comments">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Positioning of Interlinear Comments</span>
+        <span its-locale-filter-list="en" lang="en">Positioning of interlinear comments</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行间批语的排版</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間批語的排版</span>
       </h4>
@@ -2040,7 +2040,7 @@ var respecConfig = {
 
 <section id="handling_interlinear_punctuation">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Handling Interlinear Punctuation</span>
+        <span its-locale-filter-list="en" lang="en">Handling interlinear punctuation</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行间标点的处理</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間標點的處理</span>
       </h4>
@@ -2181,7 +2181,7 @@ var respecConfig = {
 
 <section id="prohibition_rules_for_line_start_end">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Prohibition Rules for Line Start and Line End</span>
+        <span its-locale-filter-list="en" lang="en">Prohibition rules for line start and line end</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行首行尾禁则</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行首行尾禁則</span>
       </h4>
@@ -2306,14 +2306,14 @@ var respecConfig = {
 
 <section id="prohibition_rules_for_unbreakable_marks">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Prohibition Rules for Unbreakable Marks</span>
+        <span its-locale-filter-list="en" lang="en">Prohibition rules for unbreakable marks</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">符号分离禁则</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">符號分離禁則</span>
       </h4>
 
       <section id="h-unbreakable_marks_punctuation">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Punctuation Marks</span>
+          <span its-locale-filter-list="en" lang="en">Punctuation marks</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號</span>
         </h5>
@@ -2338,7 +2338,7 @@ var respecConfig = {
 
       <section id="h-digits_and_their_prefix_and_suffix">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Digits and their Prefix and Suffix</span>
+          <span its-locale-filter-list="en" lang="en">Digits and their prefix and suffix</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">数字及其相应的前后缀单位符号</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">數字及其相應的前後綴單位符號</span>
         </h5>
@@ -2347,7 +2347,7 @@ var respecConfig = {
 
       <section id="h-annotation_marks">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Annotation Marks</span>
+          <span its-locale-filter-list="en" lang="en">Annotation marks</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">注释符号</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">注釋符號</span>
         </h5>
@@ -2357,7 +2357,7 @@ var respecConfig = {
 
 <section id="hanging_punctuation_marks_at_line_end">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Hanging Punctuation at Line End</span>
+        <span its-locale-filter-list="en" lang="en">Hanging punctuation at line end</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行尾点号悬挂</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行尾點號懸掛</span>
       </h4>
@@ -2379,7 +2379,7 @@ var respecConfig = {
 
     <section id="id114">
       <h4>
-            <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
+            <span its-locale-filter-list="en" lang="en">Handling Western text in Chinese text using proportional Western fonts</span>
             <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
             <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
     </h4>
@@ -2412,14 +2412,14 @@ var respecConfig = {
 
 <section id="paragraph_adjustment_rules">
     <h3>
-      <span its-locale-filter-list="en" lang="en">Paragraph Adjustment Rules</span>
+      <span its-locale-filter-list="en" lang="en">Paragraph adjustment rules</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">段落调整</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">段落調整</span>
     </h3>
 
     <section id="first_line_indents">
       <h4>
-        <span its-locale-filter-list="en" lang="en" class="checkme">First-line Indents</span>
+        <span its-locale-filter-list="en" lang="en" class="checkme">First-line indents</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">段首缩排</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">段首縮排</span>
       </h4>
@@ -2553,14 +2553,14 @@ var respecConfig = {
 
 <section id="line_adjustment">
   <h3>
-    <span its-locale-filter-list="en" lang="en">Line Adjustment</span>
+    <span its-locale-filter-list="en" lang="en">Line adjustment</span>
     <span its-locale-filter-list="zh-hans" lang="zh-hans">行内调整</span>
     <span its-locale-filter-list="zh-hant" lang="zh-hant">行內調整</span>
   </h3>
 
   <section id="necessity_for_line_adjustment">
     <h4>
-      <span its-locale-filter-list="en" lang="en">Necessity for Line Adjustment</span>
+      <span its-locale-filter-list="en" lang="en">Necessity for line adjustment</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">行内调整的必要性</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">行內調整的必要性</span>
     </h4>
@@ -2646,7 +2646,7 @@ var respecConfig = {
 
   <section id="reduction_and_expansion_of_inter-character_spacing">
     <h4>
-      <span its-locale-filter-list="en" lang="en">Reduction and Expansion of Inter-Character Spacing</span>
+      <span its-locale-filter-list="en" lang="en">Reduction and expansion of inter-character spacing</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">挤压处理和拉伸处理</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">擠壓處理和拉伸處理</span>
     </h4>
@@ -2715,7 +2715,7 @@ var respecConfig = {
 
   <section id="procedures_for_inter-character_spacing_reduction">
     <h4>
-      <span its-locale-filter-list="en" lang="en">Procedures for Inter-Character Spacing Reduction</span>
+      <span its-locale-filter-list="en" lang="en">Procedures for inter-character spacing reduction</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">挤压处理的优先顺序</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">擠壓處理的優先順序</span>
     </h4>
@@ -2852,7 +2852,7 @@ var respecConfig = {
 
   <section id="procedures_for_inter-character_space_expansion">
     <h4>
-      <span its-locale-filter-list="en" lang="en">Procedures for Inter-Character Space Expansion</span>
+      <span its-locale-filter-list="en" lang="en">Procedures for inter-character space expansion</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">拉伸处理的优先顺序</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">拉伸處理的優先順序</span>
     </h4>
@@ -2944,7 +2944,7 @@ var respecConfig = {
 
 <section id="id116">
   <h4>
-        <span its-locale-filter-list="en" lang="en">Handling Western Text in Chinese Text Using Proportional Western Fonts</span>
+        <span its-locale-filter-list="en" lang="en">Handling Western text in Chinese text using proportional Western fonts</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">西文使用比例字体时的混排处理</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">西文使用比例字體時的混排處理</span>
 </h4>
@@ -2956,7 +2956,7 @@ var respecConfig = {
 
 <section id="handling_of_grid_alignment_in_chinese_and_western_mixed_text_composition">
   <h4>
-    <span its-locale-filter-list="en" lang="en">Handling of Grid Alignment in Chinese and Western Mixed Text Composition</span>
+    <span its-locale-filter-list="en" lang="en">Handling of grid alignment in Chinese and Western mixed text composition</span>
     <span its-locale-filter-list="zh-hans" lang="zh-hans">纵横对齐下的中西文混排处理</span>
     <span its-locale-filter-list="zh-hant" lang="zh-hant">縱橫對齊下的中西文混排處理</span>
   </h4>
@@ -3022,7 +3022,7 @@ var respecConfig = {
 
 <section id="principles_of_arrangement_of_han_characters">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Principles for Arranging Characters during Chinese Composition</span>
+        <span its-locale-filter-list="en" lang="en">Principles for arranging characters during Chinese composition</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">汉字的配置原则</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">漢字的配置原則</span>
       </h4>
@@ -3171,7 +3171,7 @@ var respecConfig = {
 
       <section id="h-punctuation_adjustment_space">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Punctuation Adjustment Space</span>
+          <span its-locale-filter-list="en" lang="en">Punctuation adjustment space</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">标点符号的调整空间</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">標點符號的調整空間</span>
         </h5>
@@ -3274,7 +3274,7 @@ var respecConfig = {
 
 <section id="mixed_text_composition_in_horizontal_writing_mode">
   <h4>
-    <span its-locale-filter-list="en" lang="en">Mixed Text Composition in Horizontal Writing Mode</span>
+    <span its-locale-filter-list="en" lang="en">Mixed text composition in horizontal writing mode</span>
     <span its-locale-filter-list="zh-hans" lang="zh-hans">横排的中、西文混排配置</span>
     <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排的中、西文混排配置</span>
   </h4>
@@ -3454,7 +3454,7 @@ var respecConfig = {
 
     <section id="main_elements_of_basic_composition">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Basic Elements of Page Formatting</span>
+        <span its-locale-filter-list="en" lang="en">Basic elements of page formatting</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">排版样式的主要元素</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">排版樣式的主要元素</span>
       </h4>
@@ -3494,7 +3494,7 @@ var respecConfig = {
 
     <section id="designing_elements_of_type_area">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Design of the Type Area</span>
+        <span its-locale-filter-list="en" lang="en">Design of the type area</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">基本版式的设计元素</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">基本版式的設計元素</span>
       </h4>
@@ -3544,7 +3544,7 @@ var respecConfig = {
 
     <section id="using_type_area_for_composition_in_real_pages">
       <h4>
-        <span its-locale-filter-list="en" lang="en">From the Template of the Page Format to the Actual Page Format</span>
+        <span its-locale-filter-list="en" lang="en">From the template of the page format to the actual page format</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">从基本版式到实际版面的定版设计</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">從基本版式到實際版面的定版設計</span>
       </h4>
@@ -3574,7 +3574,7 @@ var respecConfig = {
 
     <section id="procedure_for_defining_type_area">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Procedure for Defining the Type Area</span>
+        <span its-locale-filter-list="en" lang="en">Procedure for defining the type area</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">设计基本版式的步骤</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">設計基本版式的步驟</span>
       </h4>
@@ -3635,7 +3635,7 @@ var respecConfig = {
 
     <section id="considerations_in_designing_type_area">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Considerations when Designing the Type Area</span>
+        <span its-locale-filter-list="en" lang="en">Considerations when designing the type area</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">基本版式设计的注意事项</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">基本版式設計的注意事項</span>
       </h4>
@@ -3912,7 +3912,7 @@ var respecConfig = {
 
 <section id="adjustments_of_orphans_and_widows">
       <h4>
-      <span its-locale-filter-list="en" lang="en">Handling of Widows and Orphans</span>
+      <span its-locale-filter-list="en" lang="en">Handling of widows and orphans</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">孤行与孤字处理</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">孤行與孤字處理</span>
       </h4>
@@ -4024,14 +4024,14 @@ var respecConfig = {
 
   <section id="handling_of_headings">
     <h3>
-      <span its-locale-filter-list="en" lang="en">Headings &amp; Page Breaks</span>
+      <span its-locale-filter-list="en" lang="en">Headings &amp; page breaks</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">标题处理（包含换页处理）</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">標題處理（包含換頁處理）</span>
     </h3>
 
     <section id="types_of_headings">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Types of Headings</span>
+        <span its-locale-filter-list="en" lang="en">Types of headings</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">标题的种类</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">標題的種類</span>
       </h4>
@@ -4095,7 +4095,7 @@ var respecConfig = {
 
     <section id="styling_of_headings">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Font Selection and Heading Font Size</span>
+        <span its-locale-filter-list="en" lang="en">Font selection and heading font size</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">突显标题的方式</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">突顯標題的方式</span>
       </h4>
@@ -4150,7 +4150,7 @@ var respecConfig = {
 
     <section id="handling_of_new_retros">
       <h4>
-        <span its-locale-filter-list="en" lang="en">How to Handle Headings with New Recto and Page Break</span>
+        <span its-locale-filter-list="en" lang="en">How to handle headings with new recto and page break</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">单页起、换页处理</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">單頁起、換頁處理</span>
       </h4>
@@ -4185,7 +4185,7 @@ var respecConfig = {
 
     <section id="handling_of_spaces_before_new_rectos">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Handling of Spaces just before the New Recto, Page Breaks and New Edges</span>
+        <span its-locale-filter-list="en" lang="en">Handling of spaces just before the new recto, page breaks and new edges</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">单页起、换页处理时，前一页的处理</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">單頁起、換頁處理時，前一頁的處理</span>
       </h4>
@@ -4220,7 +4220,7 @@ var respecConfig = {
 
     <section id="processing_of_runin_headings">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Processing of Run-in Headings</span>
+        <span its-locale-filter-list="en" lang="en">Processing of run-in headings</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">同行标题的处理方式</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">同行標題的處理方式</span>
       </h4>


### PR DESCRIPTION
[Preview](https://deploy-preview-633--clreq.netlify.app/indexnew)

Partial fix for #629. We need to rename `indexNEW.html` to `index.html` after merging this PR.

Based on our special meeting, some sections have been reorganised and the Chinese text has been adjusted according to the translation in https://github.com/w3c/clreq/issues/629#issuecomment-2270501142 .
