### PR TITLE
Mention emphasis mark in mixed text composition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1436,11 +1436,11 @@ var respecConfig = {
           <div class="note" id="emphasis-marks-embedded">
             <p its-locale-filter-list="en" lang="en">Unlike Chinese, emphasis dots in horizontal Japanese text are placed above the text. When Japanese text is embedded in Chinese or vice versa, the use of emphasis dots should follow the style of the main language of the text. For example, if Chinese text contains fragments of text in Japanese or another language, the entire punctuation system, including emphasis dots, should remain in the Chinese style. Even if there is Japanese text, emphasis dots should still be placed below the corresponding text to maintain the consistency and readability of Chinese layout. Similarly, in a text that is mainly in Japanese, embedded Chinese content should also follow Japanese layout rules and place emphasis dots above the text.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">与中文不同，横排日文文本中的着重号位于文本上方。当中文与日文文本相互嵌入时，着重号的使用需遵循文本的主要语言风格。例如，如果中文文本中包含日文或其他语言的片段，那么包括着重号在内的整个标点符号系统应保持中文风格。即使文本中混有日文，着重号也应位于相应文本部分的下方，以维持中文排版的一致性和可读性。同理，在以日文为主的文本中，嵌入的中文内容也应遵循日文排版规则，将着重号置于文本上方。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">與中文不同，橫排日文文本中的著重號位于文本上方。當中文與日文文本相互嵌入時，著重號的使用需遵循文本的主要語言風格。例如，如果中文文本中包含日文或其他語言的片段，那麽包括著重號在內的整個標點符號系統應保持中文風格。即使文本中混有日文，著重號也應位于相應文本部分的下方，以維持中文排版的壹致性和可讀性。同理，在以日文爲主的文本中，嵌入的中文內容也應遵循日文排版規則，將著重號置于文本上方。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">與中文不同，橫排日文文本中的著重號位于文本上方。當中文與日文文本相互嵌入時，著重號的使用需遵循文本的主要語言風格。例如，如果中文文本中包含日文或其他語言的片段，那麽包括著重號在內的整個標點符號系統應保持中文風格。即使文本中混有日文，著重號也應位于相應文本部分的下方，以維持中文排版的壹致性和可讀性。同理，在以日文爲主的文本中，嵌入的中文內容也應遵循日文排版規則，將著重號置于文本上方。</p>
 
-            <p its-locale-filter-list="en" lang="en" class="checkme">This rule ensures that the overall style and visual effect are not damaged in mixed text composition.</p>
+            <p its-locale-filter-list="en" lang="en">This rule ensures that the overall style and visual effect are not damaged in mixed text composition.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">这一规则确保了在多语言混排情境下，中文排版的整体风格和视觉效果不受破坏。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">這一規則確保了在多語言混排情境下，中文排版的整體風格和視覺效果不受破壞。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">這一規則確保了在多語言混排情境下，中文排版的整體風格和視覺效果不受破壞。</p>
           </div>
 
 

--- a/index.html
+++ b/index.html
@@ -1433,6 +1433,17 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans">台湾教育部的《重订标点符号手册》（2008年修订版）中未收录此符号，但仍可见于部分台湾的出版物。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">台灣教育部的《重訂標點符號手冊》（2008年修訂版）中未收錄此符號，但仍可見於部分台灣的出版物</p>
 
+          <div class="note" id="emphasis-marks-embedded">
+            <p its-locale-filter-list="en" lang="en">Unlike Chinese, emphasis dots in horizontal Japanese text are placed above the text. When Japanese text is embedded in Chinese or vice versa, the use of emphasis dots should follow the style of the main language of the text. For example, if Chinese text contains fragments of text in Japanese or another language, the entire punctuation system, including emphasis dots, should remain in the Chinese style. Even if there is Japanese text, emphasis dots should still be placed below the corresponding text to maintain the consistency and readability of Chinese layout. Similarly, in a text that is mainly in Japanese, embedded Chinese content should also follow Japanese layout rules and place emphasis dots above the text.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">与中文不同，横排日文文本中的着重号位于文本上方。当中文与日文文本相互嵌入时，着重号的使用需遵循文本的主要语言风格。例如，如果中文文本中包含日文或其他语言的片段，那么包括着重号在内的整个标点符号系统应保持中文风格。即使文本中混有日文，着重号也应位于相应文本部分的下方，以维持中文排版的一致性和可读性。同理，在以日文为主的文本中，嵌入的中文内容也应遵循日文排版规则，将着重号置于文本上方。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">與中文不同，橫排日文文本中的著重號位于文本上方。當中文與日文文本相互嵌入時，著重號的使用需遵循文本的主要語言風格。例如，如果中文文本中包含日文或其他語言的片段，那麽包括著重號在內的整個標點符號系統應保持中文風格。即使文本中混有日文，著重號也應位于相應文本部分的下方，以維持中文排版的壹致性和可讀性。同理，在以日文爲主的文本中，嵌入的中文內容也應遵循日文排版規則，將著重號置于文本上方。</p>
+
+            <p its-locale-filter-list="en" lang="en" class="checkme">This rule ensures that the overall style and visual effect are not damaged in mixed text composition.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">这一规则确保了在多语言混排情境下，中文排版的整体风格和视觉效果不受破坏。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">這一規則確保了在多語言混排情境下，中文排版的整體風格和視覺效果不受破壞。</p>
+          </div>
+
+
 </section>
 </section>
 


### PR DESCRIPTION
Fix #149.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/640.html" title="Last updated on Jan 16, 2025, 5:07 AM UTC (f6b1e75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/640/f228926...f6b1e75.html" title="Last updated on Jan 16, 2025, 5:07 AM UTC (f6b1e75)">Diff</a>