### PR TITLE
Revise translation of small words

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,9 +123,30 @@ var respecConfig = {
     <p its-locale-filter-list="zh-hant" lang="zh-hant">W3C中文布局任務團成員陳慧晶、陳奕鈞、董福興、李安琪、梁海、劉慶、錢爭予、薛富僑和Richard Ishida提供了信息和翻譯。</p>
 
     <p its-locale-filter-list="en" lang="en">Special thanks to the following people who contributed to this document (contributors' names listed in in alphabetic order). </p>
-    <p its-locale-filter-list="zh-hans" lang="zh-hans">感谢以下参与者对本文档的建议与补充（依字母及拼音顺序排列）：</p>
-    <p its-locale-filter-list="zh-hant" lang="zh-hant">感謝以下參與者對本文檔的建議與補充（依字母及拼音順序排列）：</p>
-    <p class="acknowledgement">Addison Phillips, Buernia, 陳穎青, Du Yuang, Hao Chen, Hawkeyes Wind, 贺师俊 John Hax (百姓网), 侯迈 MieMie (豆瓣), NFSL2001, Jiang Jiang (Opera), 吕康豪 Kang-hao Lu (BGI), 李喆明 Austin Lee, 林可锟 Kirk Lin, Percy Ma, phy25, 吴小倩 Xiaoqian Wu (W3C), 权循真 Xidorn Quan (Mozilla), SyaoranHinata, technommy, and Virgil Ming, 张爱杰 Aijie Zhang (中国移动通信集团公司).</p>
+    <p its-locale-filter-list="zh-hans" lang="zh-hans">感谢以下参与者对本文档的建议与补充（依字母顺序排列）：</p>
+    <p its-locale-filter-list="zh-hant" lang="zh-hant">感謝以下參與者對本文檔的建議與補充（依字母順序排列）：</p>
+    <p class="acknowledgement">Addison Phillips,
+       张爱杰 Aijie Zhang (中国移动通信集团公司),
+       李喆明 Austin Lee,
+       Buernia,
+       陳穎青,
+       Du Yuang,
+       Hao Chen,
+       Hawkeyes Wind,
+       Jiang Jiang (Opera),
+       贺师俊 John Hax (百姓网),
+       吕康豪 Kang-hao Lu (BGI),
+       林可锟 Kirk Lin,
+       侯迈 MieMie (豆瓣),
+       NFSL2001,
+       Percy Ma,
+       phy25,
+       SyaoranHinata,
+       technommy,
+       and Virgil Ming,
+       吴小倩 Xiaoqian Wu (W3C),
+       权循真 Xidorn Quan (Mozilla),
+       YDX-2147483647.</p>
     <p its-locale-filter-list="en" lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/clreq/graphs/contributors">GitHub contributors list</a>.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">欲了解最新的参与者信息，请参看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub贡献者列表</a>。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">欲了解最新的參與者信息，請參看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub貢獻者列表</a>。</p>

--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ var respecConfig = {
 <ul>
 <li id="id67">
 <p its-locale-filter-list="en" lang="en">One by one, with the same upright orientation as Han characters. This usually applies to single-letter alphanumerics, and acronyms.</p>
-<p its-locale-filter-list="zh-hans" lang="zh-hans">与汉字采相同的书写方向，依字母逐个排列，主要用于单一西文字母或阿拉伯数字，以及首字母缩略词等。</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">与汉字采用相同的书写方向，依字母逐个排列，主要用于单一西文字母或阿拉伯数字，以及首字母缩略词等。</p>
 <p its-locale-filter-list="zh-hant" lang="zh-hant">與漢字採相同的書寫方向，依字母逐個排列，主要用於單一西文字母或阿拉伯數字，以及首字母縮略詞等。</p>
 <figure id="latin-one-by-one"> <img its-locale-filter-list="en" lang="en" src="images/en/latin-one-by-one.svg" alt="Arrangement of Western text in vertical writing mode—normal orientation." width="123" height="181"> <img its-locale-filter-list="zh-hans" lang="zh-hans" src="images/zh/latin-one-by-one-Hans.svg" alt="直排中的西文排版示例1" width="123" height="181"> <img its-locale-filter-list="zh-hant" lang="zh-hant" src="images/zh/latin-one-by-one-Hant.svg" alt="直排中的西文排版示例1" width="123" height="181">
 <figcaption> <span its-locale-filter-list="en" lang="en">Arrangement of Western text in vertical writing mode—normal orientation.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">直排中的西文排版示例1</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">直排中的西文排版示例1</span> </figcaption>
@@ -509,15 +509,15 @@ var respecConfig = {
 所描述的單元格排列方向，可能是不同的。例如，中國大陸的「行」通常指一組水平排列的單元格，「列」指一組垂直排列的單元格；而臺灣、香港地區的「行」通常指一組垂直排列的單元格，「列」（或「欄」）指一組水平排列的單元格。</p>
 <p its-locale-filter-list="en" lang="en" class="checkme"> This document uses row/column in logical directions consistently, i.e., "row" is vertical in vertical writing mode and horizontal in horizontal writing mode, and "column" is horizontal in vertical writing mode and vertical in horizontal writing mode. </p>
 <p its-locale-filter-list="zh-hans" lang="zh-hans">本文档采用“逻辑行”“逻辑列”来统一表述，也即，“行”在直排模式下垂直、在横排模式下水平，“列”在直排模式下水平、在横排模式下垂直。</p>
-<p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本文檔采用「邏輯行」「邏輯列」來統一表述，也即，「行」在直排模式下垂直、在橫排模式下水平，「列」在直排模式下水平、在橫排模式下垂直。</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">本文檔採用「邏輯行」「邏輯列」來統一表述，也即，「行」在直排模式下垂直、在橫排模式下水平，「列」在直排模式下水平、在橫排模式下垂直。</p>
 </div>
 </li>
 </ol>
 </li>
 <li id="id74">
 <p its-locale-filter-list="en" lang="en">Arrangement of an incomplete number of lines on a multi-column format page due to new recto, page break, or other reason.</p>
-<p its-locale-filter-list="zh-hans" lang="zh-hans">换页、换章时最末页采多栏排列、行于页面结束时，依以下方式处理：</p>
-<p its-locale-filter-list="zh-hant" lang="zh-hant">換頁、換章時最末頁採多欄排列、行於頁面結束時，依以下方式處理：</p>
+<p its-locale-filter-list="zh-hans" lang="zh-hans">换页、换章时最末页为多栏排列、行于页面结束时，依以下方式处理：</p>
+<p its-locale-filter-list="zh-hant" lang="zh-hant">換頁、換章時最末頁為多欄排列、行於頁面結束時，依以下方式處理：</p>
 <ol>
 <li id="id75">
 <p its-locale-filter-list="en" lang="en">In vertical writing mode, just finish the line where it ends. The number of lines in each column is not uniform.</p>
@@ -1094,7 +1094,7 @@ var respecConfig = {
 
             <div class="note" id="n021">
               <p its-locale-filter-list="en" lang="en">In many college textbooks, science and technology literature, and grammar books of Western languages for example, most of which are in horizontal writing mode, where Western text are heavily used. In these cases, <span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．] can be used as periods, while <span class="uname" translate="no">U+002C COMMA</span> [,] or <span class="uname" translate="no">U+FF0C FULLWIDTH COMMA</span> [，] can be used as commas or secondary commas.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">许多理工书籍、科技文献、西文教科书、语法书籍等内含大量西文词句，并采用横排，为求标点符号体例一致，也有采用<span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．]为句号、采<span class="uname" translate="no">U+002C COMMA</span> [,]或<span class="uname" translate="no">U+FF0C FULLWIDTH COMMA</span> [，]为逗号与顿号的案例。详见[[[#atypical_punctuation_marks_and_their_arrangements]]]节。</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">许多理工书籍、科技文献、西文教科书、语法书籍等内含大量西文词句，并采用横排，为求标点符号体例一致，也有采用<span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．]为句号、采用<span class="uname" translate="no">U+002C COMMA</span> [,]或<span class="uname" translate="no">U+FF0C FULLWIDTH COMMA</span> [，]为逗号与顿号的案例。详见[[[#atypical_punctuation_marks_and_their_arrangements]]]节。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">許多理工書籍、科技文獻、西文教科書、語法書籍等內含大量西文詞句，並採用橫排，為求標點符號體例一致，也有採用<span class="uname" translate="no">U+FF0E FULLWIDTH FULL STOP</span> [．]為句號、採<span class="uname" translate="no">U+002C COMMA</span> [,]或<span class="uname" translate="no">U+FF0C FULLWIDTH COMMA</span> [，]為逗號與頓號的案例。詳見[[[#atypical_punctuation_marks_and_their_arrangements]]]節。</p>
             </div>
           </li>
@@ -2387,8 +2387,8 @@ var respecConfig = {
     </h4>
     
           <p its-locale-filter-list="en" lang="en" class="checkme">Western words/phrases should not break across a line-break in horizontal writing mode or in vertical writing mode where the words/phrases are rotated 90 degrees clockwise, except where hyphenation is allowed.</p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans">横排中混排的西文单词，及直排中将文字采顺时针旋转90°配置的西文单词，在可使用连字符处之外，不得分隔为两行。</p>
-          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">橫排中混排的西文單詞，及直排中將文字采順時針旋轉90°配置的西文單詞，在可使用連字符處之外，不得分隔爲兩行。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans">横排中混排的西文单词，及直排中将文字顺时针旋转90°配置的西文单词，在可使用连字符处之外，不得分隔为两行。</p>
+          <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">橫排中混排的西文單詞，及直排中將文字順時針旋轉90°配置的西文單詞，在可使用連字符處之外，不得分隔爲兩行。</p>
     </section>
 
 </section>
@@ -2544,7 +2544,7 @@ var respecConfig = {
             </li>
             <li id="id163">
               <p its-locale-filter-list="en" lang="en">Even inter-character spacing is often used for listing names of people or objects. The last line of a paragraph or a paragraph with only one line can have even inter-character spacing applied as well.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">在列表中，如列举人名、物品名时，采均排以求体例一致，当段落末行或段落仅有一行时，亦使用均排。</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">在列表中，如列举人名、物品名时，采用均排以求体例一致，当段落末行或段落仅有一行时，亦使用均排。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">於列表，如列舉人名、物品名時，採均排以求體例一致，於段落末行或段落僅有一行時，亦使用均排。</p>
             </li>
           </ol>
@@ -3930,7 +3930,7 @@ var respecConfig = {
           <ol>
             <li id="id165">
               <p its-locale-filter-list="en" lang="en">Similar to the handling for the <a href="#prohibition_rules_for_line_start_end">prohibition rule</a> that punctuation marks should not appear at the line start, the last character of the previous line can be moved to the next line, and the previous line should apply even inter-character spacing.</p>
-              <p its-locale-filter-list="zh-hans" lang="zh-hans">按照<a href="#prohibition_rules_for_line_start_end">避头点的处理方式</a>，由前一行取一字至末行，前一行采均排。</p>
+              <p its-locale-filter-list="zh-hans" lang="zh-hans">按照<a href="#prohibition_rules_for_line_start_end">避头点的处理方式</a>，由前一行取一字至末行，前一行采用均排。</p>
               <p its-locale-filter-list="zh-hant" lang="zh-hant">比照<a href="#prohibition_rules_for_line_start_end">避頭點的處理方式</a>，由前一行取一字至末行，前一行採均排。</p>
             </li>
             <li id="id166">
@@ -4122,7 +4122,7 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">使用的字體使用黑體，或者採用宋體但加粗。此外，也有使用圓體、楷體的案例。</p>
           <div class="note" id="n056">
             <p its-locale-filter-list="en" lang="en">In letterpress printing, when Song is used as the type face of the heading, it is always designed with a larger size; while in digital printing, due to its special typography, simply increasing the font size is not enough, the characters usually use bold style to indicate emphasis.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">活版印刷使用作为标题的宋体字，其活字设计时都会因为供标题使用而字重偏重。但使用数字字体时由于是采内文字设计，放大字级后显得过轻，几乎都会加重字重为粗体。</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">活版印刷使用作为标题的宋体字，其活字设计时都会因为供标题使用而字重偏重。但使用数字字体时由于是采用内文字设计，放大字级后显得过轻，几乎都会加重字重为粗体。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">活版印刷使用作為標題的宋體字，其活字設計時都會因為供標題使用而字重偏重。但使用數位字體時由於是採內文字設計，放大字級後顯得過輕，幾乎都會加重字重為粗體。</p>
           </div>
           <div class="note" id="n057">
@@ -4233,7 +4233,7 @@ var respecConfig = {
       <ol>
         <li id="id192">
           <p its-locale-filter-list="en" lang="en">The run-in heading is set with the same character size as the main text and in Hei or Kai. </p>
-          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">与内文采相同文字尺寸，字体改为黑体或者楷体。</p>
+          <p its-locale-filter-list="zh-hans" lang="zh-hans" class="checkme">与内文采用相同文字尺寸，字体改为黑体或者楷体。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">與內文採相同文字尺寸，字體改為黑體或者楷體。</p>
         </li>
         <li id="id193">


### PR DESCRIPTION
- zh-hans: `采` → `采用`/`为`/ (deleted)
- zh-hant: `采`/`採` → `採`/`採用`/`為`/ (deleted)

This PR does not resolve other problems described in https://github.com/w3c/clreq/issues/644#issuecomment-2582502932.

Relates-to: #644


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/YDX-2147483647/clreq/pull/645.html" title="Last updated on Jan 17, 2025, 1:24 AM UTC (a13f1a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/645/3d6a2b8...YDX-2147483647:a13f1a8.html" title="Last updated on Jan 17, 2025, 1:24 AM UTC (a13f1a8)">Diff</a>