### PR TITLE
fix: improve wording in Chinese text for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3278,10 +3278,10 @@ var respecConfig = {
           In principle, the compression should let the opening and closing bracket be close to the isolated segment of text.
         </p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">
-          挤压方向判定原则上应该让开始、结束夹注符号应紧靠被夹注的内容。
+          挤压方向判定原则上应该让开始、结束夹注符号紧靠被夹注的内容。
         </p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">
-          擠壓方向判定原則上應該讓開始、結束夾注符號應緊靠被夾注的內容。
+          擠壓方向判定原則上應該讓開始、結束夾注符號緊靠被夾注的內容。
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@ var respecConfig = {
        and Virgil Ming,
        吴小倩 Xiaoqian Wu (W3C),
        权循真 Xidorn Quan (Mozilla),
-       YDX-2147483647.</p>
+       YDX-2147483647,
+       张传峰 Chuanfeng Zhang (金现代信息产业股份有限公司).</p>
     <p its-locale-filter-list="en" lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/clreq/graphs/contributors">GitHub contributors list</a>.</p>
     <p its-locale-filter-list="zh-hans" lang="zh-hans">欲了解最新的参与者信息，请参看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub贡献者列表</a>。</p>
     <p its-locale-filter-list="zh-hant" lang="zh-hant">欲了解最新的參與者信息，請參看<a href="https://github.com/w3c/clreq/graphs/contributors">GitHub貢獻者列表</a>。</p>


### PR DESCRIPTION
A very small update! I'm surprised no one spotted this before, but I think it's worth fixing as it'll improve the reading experience of the documentation, hopefully making it a bit smoother for everyone.😄


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ChuanfengZhang/clreq/pull/652.html" title="Last updated on Mar 18, 2025, 2:32 AM UTC (fe287fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/652/faa3f45...ChuanfengZhang:fe287fa.html" title="Last updated on Mar 18, 2025, 2:32 AM UTC (fe287fa)">Diff</a>