### PR TITLE
Make the two-em dashes text clearer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1173,7 +1173,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hans" lang="zh-hans"><span class="leadin">破折号</span></p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant"><span class="leadin">破折號</span></p>
 
-            <p its-locale-filter-list="en" lang="en">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or add new content to the context, appearing as a horizontally and vertically centered line, and have a width of 2&nbsp;em. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] characters are also often used.</p>
+            <p its-locale-filter-list="en" lang="en">Two-em dashes show a continuation of tone or sound, an abrupt change in thought, or add new content to the context. In both horizontal text and vertical text, the two-em dash should be centered in the character frame, and have a width of 2&nbsp;em. Using <span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺] is recommended, but two adjacent <span class="uname" translate="no">U+2014 EM DASH</span> [—] characters are also often used.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">破折号表示语气或声音的延续、语意的转换或行文的补充。呈现上为一条在水平和垂直方向均位于字面正中的直线，占两个汉字空间。推荐使用占两个汉字宽度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用两个连续的<span class="uname" translate="no">U+2014 EM DASH</span> [—]来实现。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="checkme">破折號表示語氣或聲音的延續、語意的轉換或行文的補充。呈現上為一條在水平和垂直方向均位於字面正中的直線，占兩個漢字空間。推薦使用占兩個漢字寬度的<span class="uname" translate="no">U+2E3A TWO-EM DASH</span> [⸺]，但通常也使用兩個連續的<span class="uname" translate="no">U+2014 EM DASH</span> [—]來實現。</p>
 


### PR DESCRIPTION
Emphasize that it is centered in both horizontal and vertical text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/657.html" title="Last updated on Feb 18, 2025, 7:46 AM UTC (583e4c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/657/6a6acc1...583e4c0.html" title="Last updated on Feb 18, 2025, 7:46 AM UTC (583e4c0)">Diff</a>