### PR TITLE
Fix #651

### DIFF
--- a/index.html
+++ b/index.html
@@ -1612,9 +1612,9 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en" class="leadin">Bilingual Annotations.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans" class="leadin">中外文对照</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant" class="leadin">中外文對照</p>
-            <p its-locale-filter-list="en" lang="en">Bilingual annotations aim to provide a Chinese translation of text in foreign languages or acronyms, or to offer the original text for words that have been translated into Chinese. This is mainly used for proper nouns, titles or those terms whose concepts are difficult to convey after translation. It is commonly found in translated works, mainly in light novels.</p>
-            <p its-locale-filter-list="zh-hans" lang="zh-hans">为外来语、首字母缩略词标注其中译，或对翻译名词标注其原文，多见于专有名词、作品名及译后概念较难传达的词汇。常见于译作，尤以轻小说为主。</p>
-            <p its-locale-filter-list="zh-hant" lang="zh-hant">為外來語、首字母縮略詞標注其中譯，或對翻譯名詞標注其原文，多見於專有名詞、作品名及譯後概念較難傳達的詞彙。常見於譯作，尤以輕小說為主。</p>
+            <p its-locale-filter-list="en" lang="en">Bilingual annotations aim to provide a Chinese translation of text in foreign languages or acronyms, or to offer the original text for words that have been translated into Chinese. This is mainly used for proper nouns, titles or those terms whose concepts are difficult to convey after translation. It is commonly found in translated works.</p>
+            <p its-locale-filter-list="zh-hans" lang="zh-hans">为外来语、首字母缩略词标注其中译，或对翻译名词标注其原文，多见于专有名词、作品名及译后概念较难传达的词汇。常见于译作。</p>
+            <p its-locale-filter-list="zh-hant" lang="zh-hant">為外來語、首字母縮略詞標注其中譯，或對翻譯名詞標注其原文，多見於專有名詞、作品名及譯後概念較難傳達的詞彙。常見於譯作。</p>
             <figure id="billingual-annotation-use-case"><img width="500" height="361" alt="中外文對照行間注的排版示例" src="images/zh/billingual-annotation.svg">
               <figcaption><span its-locale-filter-list="en" lang="en">An example of positioning for billingual annotations.</span> <span its-locale-filter-list="zh-hans" lang="zh-hans">中外文对照行间注的排版示例。</span> <span its-locale-filter-list="zh-hant" lang="zh-hant">中外文對照行間注的排版示例。</span></figcaption>
             </figure>


### PR DESCRIPTION
Remove the phrase “尤以轻小说为主” from [5.5.1.2](https://w3c.github.io/clreq/#h-indicating_meaning_or_other_information) as per CLReq editors’ call on 2025-04-16.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/668.html" title="Last updated on Apr 16, 2025, 2:25 PM UTC (c720df9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/668/c1b5364...realfish:c720df9.html" title="Last updated on Apr 16, 2025, 2:25 PM UTC (c720df9)">Diff</a>