### PR TITLE
Partial fix for #355

### DIFF
--- a/index.html
+++ b/index.html
@@ -1547,14 +1547,14 @@ var respecConfig = {
 
     <section id="usage_of_interlinear_annotations">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Usage of interlinear annotations</span>
+        <span its-locale-filter-list="en" lang="en">Usage of ruby</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行间注的用途</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間注的用途</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">Chinese <a href="#term.interlinear-annotations" class="termref">interlinear annotation</a>, also known as ruby, refers to small, supplementary text attached to certain characters or words in the main text. Chinese interlinear annotation is usually set in the interlinear space and aligned to the corresponding base text which it annotates. In Chinese typesetting, Chinese interlinear annotation is mainly used to indicate pronunciation or meaning.</p>
-      <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.interlinear-annotations" class="termref">行间注</a>是标注在字词旁侧的小字号补充文本。行间注的注文通常位于行间，与其所标注的基文对齐，因这一性质而又名为行间注。行间注在中文排版里的用途主要为标音与释义。</p>
-      <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.interlinear-annotations" class="termref">行間注</a>是標注於字詞旁側的小字號補充文本。行間注的注文通常位於行間，與其所標注的基文對齊，因這一性質而又名為行間注。行間注在中文排版里的用途主要為標音與釋義。</p>
+      <p its-locale-filter-list="en" lang="en"><a href="#term.ruby" class="termref">Ruby</a> refers to small, supplementary text attached to certain characters or words in the main text. Ruby in Chinese is usually set in the interlinear space and aligned to the corresponding base text which it annotates. In Chinese typesetting, ruby is mainly used to indicate pronunciation or meaning.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans"><a href="#term.ruby" class="termref">行间注</a>是标注在字词旁侧的小字号补充文本。行间注的注文通常位于行间，与其所标注的基文对齐，因这一性质而又名为行间注。行间注在中文排版里的用途主要为标音与释义。</p>
+      <p its-locale-filter-list="zh-hant" lang="zh-hant"><a href="#term.ruby" class="termref">行間注</a>是標注於字詞旁側的小字號補充文本。行間注的注文通常位於行間，與其所標注的基文對齊，因這一性質而又名為行間注。行間注在中文排版里的用途主要為標音與釋義。</p>
       <section id="h-indicating_pronunciation_for_chinese_characters">
         <h5>
           <span its-locale-filter-list="en" lang="en">Indicating the pronunciation for Han characters</span>
@@ -1562,7 +1562,7 @@ var respecConfig = {
           <span its-locale-filter-list="zh-hant" lang="zh-hant">為漢字標注讀音</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en">In Chinese, interlinear annotation is most commonly used to indicate the pronunciation of Han characters. Presenting the pronunciation alongside the characters is a great help to beginners, especially to children who are native speakers, or to foreigners intending to study Chinese. Therefore, it is rare to annotate isolated Han characters. Instead, phonetic annotations tend to cover the full text. Also, it is not regular practice in Chinese layout to use interlinear annotation for pronunciation outside these educational contexts, even for the pronunciation of rarely used characters, although sometimes pronunciation is provided inline, possibly within brackets.</p>
+        <p its-locale-filter-list="en" lang="en">In Chinese, ruby is most commonly used to indicate the pronunciation of Han characters. Presenting the pronunciation alongside the characters is a great help to beginners, especially to children who are native speakers, or to foreigners intending to study Chinese. Therefore, it is rare to annotate isolated Han characters. Instead, phonetic annotations tend to cover the full text. Also, it is not regular practice in Chinese layout to use ruby for pronunciation outside these educational contexts, even for the pronunciation of rarely used characters, although sometimes pronunciation is provided inline, possibly within brackets.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">行间注最常见的用途是为汉字标注读音。汉字标音针对的是汉语初学者，包括母语为汉语的幼儿以及学习汉语的外国人士，因此对个别字标音的情况较少，多为全文标音。常规排版中没有行间注标音的习惯，对生僻字也几乎从不标音，即便标音也只是用行内括号标注。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">行間注最常見的用途係為漢字標注讀音。漢字標音針對的是漢語初學者，包括母語為漢語的幼兒以及學習漢語的外國人士，因此對個別字標音的情況較少，多為全文標音。常規排版中沒有行間注標音的習慣，對生僻字也幾乎從不標音，即便標音也只是用行內括號標注。</p>
         <p its-locale-filter-list="en" lang="en">There are two major annotation systems for indicating Chinese pronunciation: Bopomofo (Zhuyin) and Romanization.</p>
@@ -1589,7 +1589,7 @@ var respecConfig = {
             <p its-locale-filter-list="en" lang="en">Hanyu Pinyin (汉语拼音), now the official standard in Mainland China, uses the Latin alphabet to transcribe the Modern Standard Chinese (Mandarin) pronunciations of Han characters. The most common use case in Mainland China is to indicate the pronunciation for all characters of the full text with Hanyu Pinyin. In Taiwan and areas that use Chinese dialects in China, the arrangement of the Taiwanese Romanization System for Minnan (<span lang="zh-hant">台灣閩南語羅馬字</span>), or romanization systems of other Chinese dialects are similar to those of Hanyu Pinyin.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">使用拉丁字母的汉语拼音是中国大陆推行的现代标准汉语（普通话）标音与拉丁转写方案，汉语拼音的全文标音也是中国大陆现代最常见的行间注用例。在中国大陆与台湾，台湾闽南语罗马字拼音等各种汉语方言的拉丁字母标音方案也有与汉语拼音情况类似的行间注用例。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">使用拉丁字母的漢語拼音是中國大陸推行的現代標準漢語（普通話）標音與拉丁轉寫方案，漢語拼音的全文標音也是中國大陸現代最常見的行間注用例。在台灣與中國大陸漢語方言使用地區，台灣閩南語羅馬字拼音等各種漢語方言的拉丁字母標音方案也有與漢語拼音情況類似的行間注用例。</p>
-            <p its-locale-filter-list="en" lang="en">Due to the characteristics of the Latin alphabet, such annotations appear in horizontal writing mode only. Texts for children who are native speakers usually provide reading assistance for each individual character, while texts for those who are learning Chinese as a second language mainly indicate pronunciation for whole words, but occasionally, both of them are set almost the same. There is space between the base text when whole words are annotated, and the interlinear annotation characters will have unique requirements such as sentence case, or punctuation marks corresponding to base characters. The composition of early publications using pinyin was quite variable and not consistent. In general, both character-based and word-based annotations were quite common. No further description of the early pinyin will be found in this document.</p>
+            <p its-locale-filter-list="en" lang="en">Due to the characteristics of the Latin alphabet, such annotations appear in horizontal writing mode only. Texts for children who are native speakers usually provide reading assistance for each individual character, while texts for those who are learning Chinese as a second language mainly indicate pronunciation for whole words, but occasionally, both of them are set almost the same. There is space between the base text when whole words are annotated, and the ruby text will have unique requirements such as sentence case, or punctuation marks corresponding to base characters. The composition of early publications using pinyin was quite variable and not consistent. In general, both character-based and word-based annotations were quite common. No further description of the early pinyin will be found in this document.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">因拉丁字母的特质，此类标音文本仅横排。针对幼儿母语者的文本以单字作为基文进行标音。针对双语学习者的文本除偶有与前者一致的格式外，大多分词连写，以词作为基文进行标音，基文之间如西文书写一般用空格隔开，并且注文有句首大写、专名首字母大写等格式以及与正文对应的标点符号，自成一体。汉语拼音早期印刷品的格式较为多变，一致性不强。大体上，单字标音与分词连写标音都常见，不作详细述。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">因拉丁字母的特質，此類標音文本僅橫排。針對幼兒母語者的文本以單字作為基文進行標音。針對二語學習者的文本除偶有與前者一致的格式外，大多分詞連寫，以詞作為基文進行標音，基文之間如西文書寫般用空格隔開，並且注文有句首大寫、專名首字母大寫等格式以及與正文對應的標點符號，自成一體。漢語拼音早期印刷品的格式較為多變，一致性不強。大體上，單字標音與分詞連寫標音都常見，不作詳細描述。</p>
             <figure id="pinyin-use-case"><img width="400" height="168" alt="羅馬拼音行間注的排版示例" src="images/zh/pinyin-use-case.svg">
@@ -1636,7 +1636,7 @@ var respecConfig = {
 
     <section id="overview_of_positioning_of_interlinear_annotations">
       <h3>
-        <span its-locale-filter-list="en" lang="en">Overview of interlinear annotation positioning</span>
+        <span its-locale-filter-list="en" lang="en">Overview of ruby positioning</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">行间注排版概述</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間注排版概述</span>
       </h3>
@@ -1658,7 +1658,7 @@ var respecConfig = {
 
     <section id="positioning_of_zhuyin">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Positioning of Bopomofo interlinear annotations</span>
+        <span its-locale-filter-list="en" lang="en">Positioning of Bopomofo ruby</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">注音符号标音的排版</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">注音符號標音的排版</span>
       </h4>
@@ -1842,7 +1842,7 @@ var respecConfig = {
 
     <section id="positioning_of_romanization">
       <h4>
-        <span its-locale-filter-list="en" lang="en">Positioning of Romanized interlinear annotations</span>
+        <span its-locale-filter-list="en" lang="en">Positioning of Romanized ruby</span>
         <span its-locale-filter-list="zh-hans" lang="zh-hans">罗马拼音标音的排版</span>
         <span its-locale-filter-list="zh-hant" lang="zh-hant">羅馬拼音標音的排版</span>
       </h4>
@@ -1862,9 +1862,9 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hant" lang="zh-hant">僅橫排。注文通常置於基文上方。不論二者寬窄關系如何，注文應密排，並與基文居中對齊。</p>
             </div>
             <figure>
-              <img width="400" alt="Romanized interlinear annotations" src="images/en/romanization-basic.png">
+              <img width="400" alt="Romanized ruby" src="images/en/romanization-basic.png">
               <figcaption>
-                <span its-locale-filter-list="en" lang="en">Example of Romanized interlinear annotations.</span>
+                <span its-locale-filter-list="en" lang="en">Example of Romanized ruby.</span>
                 <span its-locale-filter-list="zh-hans" lang="zh-hans">罗马拼音标音的示例。</span>
                 <span its-locale-filter-list="zh-hant" lang="zh-hant">羅馬拼音標音的示例。</span>
               </figcaption>
@@ -3952,7 +3952,7 @@ var respecConfig = {
           <p its-locale-filter-list="en" lang="en"> The <a>line gaps</a> between each line should be the same throughout the book, except for special cases.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行与行之间的空白（行距）除特别状况外，需保持一致。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行與行之間的空白（行距）除特別狀況外，需保持一致。</p>
-          <p its-locale-filter-list="en" lang="en">In Traditional Chinese composition, there are cases where pronunciation marks, referred to as 'ruby' in the <a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">Japanese Layout Requirements</a>, are inserted between lines. In such cases the <a>line gap</a> is not changed but kept constant. If these elements are likely to occur in the text, the line gap established during type area design needs to be of an adequate size to accommodate them.</p>
+          <p its-locale-filter-list="en" lang="en">In Traditional Chinese composition, there are cases where pronunciation marks are inserted between lines. In such cases the <a>line gap</a> is not changed but kept constant. If these elements are likely to occur in the text, the line gap established during type area design needs to be of an adequate size to accommodate them.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">繁体中文排版中，字间的注音符号可能会超入行距空间，而翻译书籍也可能使用类似日文排版的<a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">ruby</a>文字，此时行距仍需保持一致。当文中需要配置这些元素时，于设计版心的阶段就须考量到这些要素来决定行距。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">繁體中文排版中，字間的注音符號可能會超入行距空間，而翻譯書籍亦可能使用類似日文排版的<a href="https://www.w3.org/TR/jlreq/#ruby_and_emphasis_dots">ruby</a>文字，此時行距仍需保持一致。當文中需要配置這些元素時，於設計版心的階段就須考量到這些要素來決定行距。</p>
           <div class="note" id="n009">
@@ -5490,7 +5490,7 @@ var respecConfig = {
         <td>biāoyīn</td>
         <td>phonetic annotation</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">The way to indicate the pronunciation of the Han characters, e.g. interlinear annotations.</p>
+          <p its-locale-filter-list="en" lang="en">The way to indicate the pronunciation of the Han characters, e.g. ruby.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">为汉字标注发音的方式，主要有行间注等。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為漢字標注發音的方式，主要有行間注等。</p>
         </td>
@@ -5723,11 +5723,11 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hant" lang="zh-hant">位於行間的批注，形態自由、長度不拘，時可超過一行。</p>
         </td>
       </tr>
-      <tr id="term.interlinear-annotations">
+      <tr id="term.ruby">
         <td>行間注</td>
         <td>行间注</td>
         <td>hángjiānzhù</td>
-        <td>interlinear annotations</td>
+        <td>ruby</td>
         <td>
           <p its-locale-filter-list="en" lang="en">Annotations between lines used to indicate the pronounciation of a word or an explanation of a word.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">标注于行间的说明或文字读音。</p>
@@ -6150,7 +6150,7 @@ var respecConfig = {
         <td>Zhōng-wàiwén duìzhào</td>
         <td>bilingual annotations</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">To prompt a Chinese term with its original or translation in the form of annotation text or base text, an instance of interlinear annotation.</p>
+          <p its-locale-filter-list="en" lang="en">To prompt a Chinese term with its original or translation in the form of annotation text or base text, an instance of ruby.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">以注文或基文的形式为汉语词组提示原文或译文，系行间注排版的一种实现方式。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">以注文或基文的形式為漢語詞組提示原文或譯文，係行間注排版的一種實作方式。</p>
         </td>


### PR DESCRIPTION
Partial fix for #355.

Change "interlinear annotations" to "ruby".

I didn't change the Chinese text for now. We discussed about changing to 标音 or 珍字.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/670.html" title="Last updated on Apr 23, 2025, 4:22 AM UTC (3a33022)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/670/b10860c...3a33022.html" title="Last updated on Apr 23, 2025, 4:22 AM UTC (3a33022)">Diff</a>