### PR TITLE
Modifying the English of 着重号

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,7 +1095,7 @@ var respecConfig = {
 <p its-locale-filter-list="zh-hans" lang="zh-hans">中文标点符号主要分为<a href="#term.pause-or-stop-punctuation-marks" class="termref">点号</a>和<a href="#term.indication-punctuation-marks" class="termref">标号</a>。点号相对于标号，用于表示语句的停顿或暂停。分为句内点号，如顿号、逗号、分号、冒号等；以及句末点号，如句号、问号、感叹号等。</p>
 <p its-locale-filter-list="zh-hant" lang="zh-hant">中文標點符號主要分爲<a href="#term.pause-or-stop-punctuation-marks" class="termref">點號</a>和<a href="#term.indication-punctuation-marks" class="termref">標號</a>。點號相對於標號，用於表示語句的停頓或暫停。分為句內點號，如頓號、逗號、分號、冒號等；以及句末點號，如句號、問號、驚嘆號等。</p>
 
-<p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses (parenthetical punctuation), two-em dashes, ellipses, emphasis dots, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
+<p its-locale-filter-list="en" lang="en">In contrast with pause or stop punctuation marks, indicator punctuation marks usually indicate a specific feature of the phrase or sentence. They include quotation marks, brackets, parentheses (parenthetical punctuation), two-em dashes, ellipses, emphasis marks, connector marks, interpuncts, book title marks, proper noun marks, and solidi.</p>
 <p its-locale-filter-list="zh-hans" lang="zh-hans">标号相对于点号，有标示词组或语句特定性质的作用。包含引号、括号（夹注号）、破折号、省略号（删节号）、着重号、连接号、间隔号、书名号、专名号、分隔号。</p>
 <p its-locale-filter-list="zh-hant" lang="zh-hant">標號相對於點號，有標示詞組或語句特定性質的作用。包含引號、括號（夾注號）、破折號、刪節號（省略號）、著重號、連接號、間隔號、書名號、專名號、分隔號。</p>
 
@@ -1448,12 +1448,12 @@ var respecConfig = {
 
   <section id="id84">
     <h2>
-      <span its-locale-filter-list="en" lang="en">Emphasis dots</span>
+      <span its-locale-filter-list="en" lang="en">Emphasis marks</span>
       <span its-locale-filter-list="zh-hans" lang="zh-hans">着重号</span>
       <span its-locale-filter-list="zh-hant" lang="zh-hant">着重號</span>
     </h2>
 
-            <p its-locale-filter-list="en" lang="en">Emphasis dots are symbols placed on the <a href="#term.line-head" class="termref">line head</a> or <a href="#term.line-foot" class="termref">line foot</a> to emphasize the text, strengthen the tone, or avoid ambiguity. For horizontal writing mode, emphasis dots are placed under the characters, whereas in vertical writing mode, they are usually placed to the right side of the characters. Both <span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●] or <span class="uname" translate="no">U+2022 BULLET</span> [•] can work as emphasis dots.</p>
+            <p its-locale-filter-list="en" lang="en">Emphasis marks, also known as emphasis dots, are symbols placed on the <a href="#term.line-head" class="termref">line head</a> or <a href="#term.line-foot" class="termref">line foot</a> to emphasize the text, strengthen the tone, or avoid ambiguity. For horizontal writing mode, emphasis marks are placed under the characters, whereas in vertical writing mode, they are usually placed to the right side of the characters. Both <span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●] or <span class="uname" translate="no">U+2022 BULLET</span> [•] can work as emphasis marks.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">着重号用于表示相应文本的强调、着重语气或避免歧义。其形态为标注于文字底端或顶端（横排多在下方〔底端〕、直排多在右侧〔顶端〕）的圆形中黑点，可以为<span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●]或<span class="uname" translate="no">U+2022 BULLET</span> [•]。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">着重號用於表示相應文本的強調、着重語氣或避免歧義。其形態為標注於文字底端或頂端（橫排多在下方〔底端〕、直排多在右側〔頂端〕）的圓形中黑點，可以為<span class="uname" translate="no">U+25CF BLACK CIRCLE</span> [●]或<span class="uname" translate="no">U+2022 BULLET</span> [•]。</p>
 
@@ -1466,7 +1466,7 @@ var respecConfig = {
             <p its-locale-filter-list="zh-hant" lang="zh-hant">句號、逗號、頓號、冒號、分號、驚嘆號、問號、破折號、刪節號、連接號、間隔號、分隔號、引號、夾注號、書名號乙式、篇名號的底端或頂端通常不再添加著重號。</p>
 
           <div class="note" id="emphasis-marks-embedded">
-            <p its-locale-filter-list="en" lang="en">Unlike Chinese, emphasis dots in horizontal Japanese text are placed above the text. When Japanese text is embedded in Chinese or vice versa, the use of emphasis dots should follow the style of the main language of the text. For example, if Chinese text contains fragments of text in Japanese or another language, the entire punctuation system, including emphasis dots, should remain in the Chinese style. Even if there is Japanese text, emphasis dots should still be placed below the corresponding text to maintain the consistency and readability of Chinese layout. Similarly, in a text that is mainly in Japanese, embedded Chinese content should also follow Japanese layout rules and place emphasis dots above the text.</p>
+            <p its-locale-filter-list="en" lang="en">Unlike Chinese, emphasis marks in horizontal Japanese text are placed above the text. When Japanese text is embedded in Chinese or vice versa, the use of emphasis marks should follow the style of the main language of the text. For example, if Chinese text contains fragments of text in Japanese or another language, the entire punctuation system, including emphasis marks, should remain in the Chinese style. Even if there is Japanese text, emphasis marks should still be placed below the corresponding text to maintain the consistency and readability of Chinese layout. Similarly, in a text that is mainly in Japanese, embedded Chinese content should also follow Japanese layout rules and place emphasis marks above the text.</p>
             <p its-locale-filter-list="zh-hans" lang="zh-hans">与中文不同，横排日文文本中的着重号位于文本上方。当中文与日文文本相互嵌入时，着重号的使用需遵循文本的主要语言风格。例如，如果中文文本中包含日文或其他语言的片段，那么包括着重号在内的整个标点符号系统应保持中文风格。即使文本中混有日文，着重号也应位于相应文本部分的下方，以维持中文排版的一致性和可读性。同理，在以日文为主的文本中，嵌入的中文内容也应遵循日文排版规则，将着重号置于文本上方。</p>
             <p its-locale-filter-list="zh-hant" lang="zh-hant">與中文不同，橫排日文文本中的著重號位于文本上方。當中文與日文文本相互嵌入時，著重號的使用需遵循文本的主要語言風格。例如，如果中文文本中包含日文或其他語言的片段，那麽包括著重號在內的整個標點符號系統應保持中文風格。即使文本中混有日文，著重號也應位于相應文本部分的下方，以維持中文排版的壹致性和可讀性。同理，在以日文爲主的文本中，嵌入的中文內容也應遵循日文排版規則，將著重號置于文本上方。</p>
 
@@ -2098,7 +2098,7 @@ var respecConfig = {
         <span its-locale-filter-list="zh-hant" lang="zh-hant">行間標點的處理</span>
       </h4>
 
-      <p its-locale-filter-list="en" lang="en">Most punctuation marks in modern Chinese typesetting are interspersed between the text in a line, but the Proper Noun Mark (underline), the Book Title Mark (only for the type A wavy low line) and the Emphasis Dot need to be positioned between lines. These punctuation marks are known as “interlinear marks”. Of which, the Proper Noun Mark and the Book Title mark are known as interlinear lines.</p>
+      <p its-locale-filter-list="en" lang="en">Most punctuation marks in modern Chinese typesetting are interspersed between the text in a line, but the Proper Noun Mark (underline), the Book Title Mark (only for the type A wavy low line) and the Emphasis Mark need to be positioned between lines. These punctuation marks are known as “interlinear marks”. Of which, the Proper Noun Mark and the Book Title mark are known as interlinear lines.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">现代中文排版的标点符号，大部分都随文字穿插在行内，但专名号（下划线）、书名号（仅指甲式的波浪线）、着重号要摆放在行与行之间，这些标点通称为“行间标点”。其中专名号（下划线）、书名号（仅指甲式的波浪线）合称为“行间线”。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">現代中文排版的標點符號，大部分都隨文字穿插在行內，但專名號（下劃線）、書名號（僅指甲式的波浪線）、著重號要擺放在行與行之間，這些標點通稱為「行間標點」。其中專名號（下劃線）、書名號（僅指甲式的波浪線）合稱為「行間線」。</p>
 
@@ -2106,7 +2106,7 @@ var respecConfig = {
       <p its-locale-filter-list="zh-hans" lang="zh-hans">传统中文古籍中的“句读”也都是“行间标点”。传统中文古籍排版虽然已经超出了本文档的范围，但是行间标点的基本原则可参照本节内容。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">傳統中文古籍中的「句讀」也都是「行間標點」。傳統中文古籍排版雖然已經超出了本文檔的範圍，但是行間標點的基本原則可參照本節內容。</p>
 
-      <p its-locale-filter-list="en" lang="en">In vertical typesetting, the interlinear lines are positioned to the left of the text, while the Emphasis Dot is positioned to the right of the text. The situation where both these marks are applied at the same time is known as double-sided setting. In horizontal typesetting, both the interlinear lines and Emphasis Dot are positioned to the bottom of the text. This situation is known as a single-side setting. In principle, text typeset horizontally will not use double-sided setting.</p>
+      <p its-locale-filter-list="en" lang="en">In vertical typesetting, the interlinear lines are positioned to the left of the text, while the Emphasis Mark is positioned to the right of the text. The situation where both these marks are applied at the same time is known as double-sided setting. In horizontal typesetting, both the interlinear lines and Emphasis Mark are positioned to the bottom of the text. This situation is known as a single-side setting. In principle, text typeset horizontally will not use double-sided setting.</p>
       <p its-locale-filter-list="zh-hans" lang="zh-hans">直排时，行间线标注于文字左侧，着重号标注于文字右侧。像这样，文字两侧均加排行间标点的排版方式叫“双面装”。横排时，行间线、着重号均标注于文字下方。像这样，文字单侧加排行间标点的排版方式叫“单面装”。原则上，横排书不使用双面装。</p>
       <p its-locale-filter-list="zh-hant" lang="zh-hant">直排時，行間線標註於文字左側，著重號標註於文字右側。像這樣，文字兩側均加排行間標點的排版方式叫「雙面裝」。橫排時，行間線、著重號均標註於文字下方。像這樣，文字單側加排行間標點的排版方式叫「單面裝」。原則上，橫排書不使用雙面裝。</p>
 
@@ -2130,11 +2130,11 @@ var respecConfig = {
           <p its-locale-filter-list="zh-hans" lang="zh-hans">为保证行间标点的摆放，单面装的行距不应小于当前字号的一半、双面装的的行距不应小于当前字号的 5/8 （=1/2+1/8）</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">為保證行間標點的擺放，單面裝的行距不應小於當前字號的一半、雙面裝的的行距不應小於當前字號的 5/8 （=1/2+1/8）</p>
 
-          <p its-locale-filter-list="en" lang="en">Emphasis Dots shall be center-aligned with its corresponding character; interlinear lines must be correspond with the length and quantity of content they are marking out. As such, if there are multiple instances which need to be marked out with interlinear lines, multiple interlinear lines need to be used. Interlinear lines cannot be arbitrarily broken up. And a single interlinear line cannot be composed out of multiple fragments. For example, if there are two adjacent Proper Nouns, even if the text being marked out is set solid, both Proper Nouns must be clearly marked with two Proper Noun Marks that are distinguishable from one another. In this instance, a single Proper Noun Mark must not be used, because this would cause the two Proper Nouns to be misunderstood as a single Proper Noun.</p>
+          <p its-locale-filter-list="en" lang="en">Emphasis Marks shall be center-aligned with its corresponding character; interlinear lines must be correspond with the length and quantity of content they are marking out. As such, if there are multiple instances which need to be marked out with interlinear lines, multiple interlinear lines need to be used. Interlinear lines cannot be arbitrarily broken up. And a single interlinear line cannot be composed out of multiple fragments. For example, if there are two adjacent Proper Nouns, even if the text being marked out is set solid, both Proper Nouns must be clearly marked with two Proper Noun Marks that are distinguishable from one another. In this instance, a single Proper Noun Mark must not be used, because this would cause the two Proper Nouns to be misunderstood as a single Proper Noun.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">着重号应与所指示的字符居中对齐；行间线应与所标注内容的长短、数量均要保持一致，即，有几个标注项目就用几条线段，不能任意从中断开，也不能用多条线段拼接组合。比如，相邻的两个专名，即使所标注的正文汉字是密排，两个专名要用两条专名线，中间的断开要能够辨认；此时不能用一条专名线连起来标注，否则连续的两个专名会被误认为是一个专名。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">著重號應與所指示的字元居中對齊；行間線應與所標註內容的長短、數量均要保持一致，即，有幾個標註項目就用幾條線段，不能任意從中斷開，也不能用多條線段拼接組合。比如，相鄰的兩個專名，即使所標註的正文漢字是密排，兩個專名要用兩條專名線，中間的斷開要能夠辨認；此時不能用一條專名線連起來標註，否則連續的兩個專名會被誤認為是一個專名。</p>
 
-          <p its-locale-filter-list="en" lang="en">Interlinear marks must be as close to the marked text as possible.<br>The thickness and size of the interlinear lines and emphasis dots is determined by the font design and typesetting rendering engine, but even though there is no absolute limitation, the sizing of these interlinear marks must be harmonious with the font size and letter-spacing of the marked text.</p>
+          <p its-locale-filter-list="en" lang="en">Interlinear marks must be as close to the marked text as possible.<br>The thickness and size of the interlinear lines and emphasis marks is determined by the font design and typesetting rendering engine, but even though there is no absolute limitation, the sizing of these interlinear marks must be harmonious with the font size and letter-spacing of the marked text.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行间标点应尽量紧贴所标注汉字一侧。<br>行间线、着重号的大小或粗度取决于字体和排版引擎的设计，虽然没有绝对限制，但显然尺寸上应与所标汉字字号、字距相匹配。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行間標點應盡量緊貼所標註漢字一側。<br>行間線、著重號的大小或粗度取決於字體和排版引擎的設計，雖然沒有絕對限制，但顯然尺寸上應與所標漢字字號、字距相匹配。</p>
         </li>
@@ -2159,7 +2159,7 @@ var respecConfig = {
             <span its-locale-filter-list="zh-hant" lang="zh-hant">橫排單面裝特殊情況</span>
           </p>
 
-          <p its-locale-filter-list="en" lang="en">By right, double-sided setting must not occur in horizontal writing mode. In cases where both a Proper Noun Mark or Book Title Mark is used together with Emphasis Dots, the guiding principle is "line first, followed by dot", such that the underline or wavy line is closer to the text, while the dot comes below.</p>
+          <p its-locale-filter-list="en" lang="en">By right, double-sided setting must not occur in horizontal writing mode. In cases where both a Proper Noun Mark or Book Title Mark is used together with Emphasis Marks, the guiding principle is "line first, followed by dot", such that the underline or wavy line is closer to the text, while the dot comes below.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">原则上，横排时不使用双面装。横排时，专名号（下划线）或书名号（仅指甲式的波浪线）如果遇到和着重号同时出现时，应以“先线后点”原则，让行间线紧贴汉字，再在其下加着重号。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">原則上，橫排時不使用雙面裝。橫排時，專名號（下劃線）或書名號（僅指甲式的波浪線）如果遇到和著重號同時出現時，應以「先線後點」原則，讓行間線緊貼漢字，再在其下加著重號。</p>
         </li>
@@ -5874,7 +5874,7 @@ var respecConfig = {
         <td>jīwén</td>
         <td>base text</td>
         <td>
-          <p its-locale-filter-list="en" lang="en">Text to be annotated by ruby, ornament characters, or emphasis dots.</p>
+          <p its-locale-filter-list="en" lang="en">Text to be annotated by ruby, ornament characters, or emphasis marks.</p>
           <p its-locale-filter-list="zh-hans" lang="zh-hans">行间注排版中，受标注的原文字词或语句。</p>
           <p its-locale-filter-list="zh-hant" lang="zh-hant">行間注排版中，受標注的原文字詞或語句。</p>
         </td>


### PR DESCRIPTION
Use "emphasis marks" instead of "emphasis dots". Fix #583.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/pull/688.html" title="Last updated on May 23, 2025, 12:24 AM UTC (833bca0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/688/9cf6e3a...833bca0.html" title="Last updated on May 23, 2025, 12:24 AM UTC (833bca0)">Diff</a>