### PR TITLE
Fix broken links across READMEs

### DIFF
--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,6 +1,6 @@
 # 中文支持 (clreq)
 
-**语言版本: [English](README.md)** | **[简体中文 (当前文档)](README.zh-cn.md)** | **[繁體中文](README.zh-tw.md)**
+**语言版本: [English](README.md)** | **[简体中文 (当前文档)](README.zh-Hans.md)** | **[繁體中文](README.zh-Hant.md)**
 
 本小组旨在探讨Web和电子书在简体和繁体中文支持方面的不足，并且记录相关需求。
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,6 +1,6 @@
 # 中文支援 (clreq)
 
-**語言版本: [English](README.md)** | **[简体中文](README.zh-cn.md)** | **[繁體中文 (當前)](README.zh-tw.md)**
+**語言版本: [English](README.md)** | **[简体中文](README.zh-Hans.md)** | **[繁體中文 (當前)](README.zh-Hant.md)**
 
 本小組旨在探討Web和電子書在簡體和繁體中文支援方面的不足，並且記錄相關需求。
 


### PR DESCRIPTION
They were wrong since the first edit. #698

In addition, the link to the English README on the website points to `/clreq/README.md` rather than `/clreq/home`.
It should be fixed, but I don't know how these pages are built, however.

- https://w3c.github.io/clreq/home
- https://w3c.github.io/clreq/README.zh-Hans.html
- https://w3c.github.io/clreq/README.zh-Hant.html
