### PR TITLE
Generate HTML for README.md

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+# https://github.com/benbalter/jekyll-optional-front-matter#one-potential-gotcha
+include:
+  - README.md


### PR DESCRIPTION
A proposal to fix w3c/clreq#706.

Cons:
1. Both README.html and home.html will exist together, but this seems to maintain the current state. I had another attempt by using frontmatter but it will drop README.md as a static asset to be published and the frontmatter feels ugly in GitHub preview.

Preview:
- Build https://github.com/phy25/clreq/actions/runs/17817534226
- https://phy25.github.io/clreq/home
- https://phy25.github.io/clreq/README.zh-Hans.html
- https://phy25.github.io/clreq/README.zh-Hant.html
- https://phy25.github.io/clreq/README.html
- [GitHub preview](https://github.com/phy25/clreq/blob/706-config-yml/README.md)