### PR TITLE
Fix #674

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,20 +1323,20 @@ var respecConfig = {
 
       <section id="symbol_of_death">
         <h5>
-          <span its-locale-filter-list="en" lang="en">Symbol of death</span>
+          <span its-locale-filter-list="en" lang="en">Death-indication mark</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">示亡号</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">示亡號</span>
         </h5>
 
-        <p its-locale-filter-list="en" lang="en">The symbol of death is not defined in the <abbr class="exclude" title="Guobiao standards">GB</abbr> rules, but is a punctuation mark which is widely used by the commons. The symbol of death is a solid black border outside the character frame of a person's name to indicate the person is deceased. Its Western counterpart would be the dagger punctuation mark (<span class="uname" translate="no">U+2020 DAGGER</span> [†] and <span class="uname" translate="no">U+2021 DOUBLE DAGGER</span> [‡]).</p>
+        <p its-locale-filter-list="en" lang="en">The death-indication mark is not defined in the <abbr class="exclude" title="Guobiao standards">GB</abbr> rules, but is a punctuation mark which is widely used by the commons. The death-indication mark is a solid black border outside the character frame of a person's name to indicate the person is deceased. Its Western counterpart would be the dagger punctuation mark (<span class="uname" translate="no">U+2020 DAGGER</span> [†] and <span class="uname" translate="no">U+2021 DOUBLE DAGGER</span> [‡]).</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">示亡号并未列于标点符号相关标准文件，但却是民间经常使用的俗用符号。示亡号亦称示殁号，为在人名文字外框描上实心的黑色边线表示已经过世，类似西文中剑标（<span class="uname" translate="no">U+2020 DAGGER</span> [†]与<span class="uname" translate="no">U+2021 DOUBLE DAGGER</span> [‡]）之用法。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">示亡號並未列於標點符號相關標準文件，但卻是民間經常使用的俗用符號。示亡號亦稱示殁號，為在人名文字外框描上實心的黑色邊線表示已經過世，類似西文中劍標（<span class="uname" translate="no">U+2020 DAGGER</span> [†]與<span class="uname" translate="no">U+2021 DOUBLE DAGGER</span> [‡]）之用法。</p>
         <figure id="death-symbol-use-case"><img width="600" height="138" alt="示亡号示例" src="images/zh/symbol-of-death.png" loading="lazy">
-          <figcaption><span its-locale-filter-list="en" lang="en">An example of the usage of symbol of death</span>
+          <figcaption><span its-locale-filter-list="en" lang="en">An example of the usage of death-indication mark</span>
           <span its-locale-filter-list="zh-hans" lang="zh-hans">示亡号用法的示例。</span>
           <span its-locale-filter-list="zh-hant" lang="zh-hant">示亡號用法的示例。</span></figcaption>
         </figure>
-        <p its-locale-filter-list="en" lang="en">The symbol of death is used to indicate a person who had been recently deceased, and is often seen in name lists, official reports, genealogy records and so on. It is not used for people who have passed away for some time or well-known deceased individuals.</p>
+        <p its-locale-filter-list="en" lang="en">The death-indication mark is used to indicate a person who had been recently deceased, and is often seen in name lists, official reports, genealogy records and so on. It is not used for people who have passed away for some time or well-known deceased individuals.</p>
         <p its-locale-filter-list="zh-hans" lang="zh-hans">示亡号主要标示于近年过世的人名，常出现在名单、公报、族谱等人名列表上，用以告知此人已亡殁。而过世已久或众所皆知的历史人物不再加注。</p>
         <p its-locale-filter-list="zh-hant" lang="zh-hant">示亡號主要標示於近年過世的人名，常出現在名單、公報、族譜等人名列表上，用以告知此人已亡歿。而過世已久或眾所皆知的歷史人物不再加註。</p>
       </section>


### PR DESCRIPTION
Fix the English term for 示亡号 by replacing “symbol of death” with “death-indication mark” (#674).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/realfish/clreq/pull/738.html" title="Last updated on Mar 5, 2026, 8:51 AM UTC (bf2f5b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/738/2f3c19a...realfish:bf2f5b1.html" title="Last updated on Mar 5, 2026, 8:51 AM UTC (bf2f5b1)">Diff</a>