### PR TITLE
Make _Chapter of the Unicode Standard_ clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1543,9 +1543,9 @@ var respecConfig = {
 <p its-locale-filter-list="zh-hant" lang="zh-hant">刪節號不得以適配分行之由斷開或拆至兩行。</p>
 
 <div class="note" id="u22ef">
-  <p its-locale-filter-list="en" lang="en">Chapter 6.2 of v14 of the Unicode Standard suggests using <span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯] for ellipses.</p>
-  <p its-locale-filter-list="zh-hans" lang="zh-hans">在Unicode标准第14版的6.2章中，也推荐使用<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]作为省略号。</p>
-  <p its-locale-filter-list="zh-hant" lang="zh-hant">在Unicode標準第14版的6.2章中，亦推薦使用<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]作為刪節號。</p>
+  <p its-locale-filter-list="en" lang="en"><a href="https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-6/#G13586">Chapter 6.2 of v17 of the Unicode Standard</a> suggests using <span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯] for ellipses.</p>
+  <p its-locale-filter-list="zh-hans" lang="zh-hans">在<a href="https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-6/#G13586">Unicode标准第17版的6.2章</a>中，也推荐使用<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]作为省略号。</p>
+  <p its-locale-filter-list="zh-hant" lang="zh-hant">在<a href="https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-6/#G13586">Unicode標準第17版的6.2章</a>中，亦推薦使用<span class="uname" translate="no">U+22EF MIDLINE HORIZONTAL ELLIPSIS</span> [⋯]作為刪節號。</p>
 
   <p its-locale-filter-list="en" lang="en">This code point, with appropriate rotation and replacement mechanism, will be centered within its character frame regardless of whether it is in vertical or horizontal writing mode, which is more in line with the Chinese typesetting requirements.</p>
   <p its-locale-filter-list="zh-hans" lang="zh-hans">此符号配合适当的转向与取代机制，在显示上无论直横排，省略点皆居中，更符合排版需求。</p>


### PR DESCRIPTION
Also change v14 to v17 because v14 did not provide per-chapter web pages.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/YDX-2147483647/clreq/pull/760.html" title="Last updated on May 29, 2026, 1:23 PM UTC (ac294ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/clreq/760/741097e...YDX-2147483647:ac294ac.html" title="Last updated on May 29, 2026, 1:23 PM UTC (ac294ac)">Diff</a>