### PR TITLE
Prevent entire appendix from becoming a scroll container

### DIFF
--- a/local.css
+++ b/local.css
@@ -195,8 +195,6 @@ code { color: #A52A2A; }
   font-weight: bold;
 }
 
-.appendix { overflow-x: auto }
-
 table { border-collapse: collapse; }
 table tr { border-bottom: 1px solid #ddd; }
 table th { padding: .25em .25em .5em .25em; }
@@ -238,6 +236,10 @@ table.charsize {
 /**
  * Tables in appendix
  */
+table.appendix {
+  display: block;
+  overflow-x: auto;
+}
 table.appendix td p { margin: .5em 0; }
 table.appendix td p:first-child { margin-top: 0; }
 table.appendix td p:last-child { margin-bottom: 0; }


### PR DESCRIPTION
This made it so that any headers inside the appendix had their left edge chopped off, meaning that the first letter looked wonky and the paragraph symbol for linking was gone. Really, only the tables should scroll. `display: block` is needed for `overflow` to apply.

Before:
<img width="885" height="598" alt="image" src="https://github.com/user-attachments/assets/a08c04d5-4221-4ee3-a7e8-b653e3458f57" />

After:
<img width="863" height="601" alt="image" src="https://github.com/user-attachments/assets/600d7f02-9dd1-490a-bedf-2d984a86f1c6" />
